### PR TITLE
Use asyncio.iscoroutine instead of inspect.isawaitable

### DIFF
--- a/src/graphql/graphql.py
+++ b/src/graphql/graphql.py
@@ -1,5 +1,4 @@
-from asyncio import ensure_future
-from inspect import isawaitable
+from asyncio import ensure_future, iscoroutine
 from typing import Any, Awaitable, Dict, Union, Type, cast
 
 from .error import GraphQLError
@@ -84,7 +83,7 @@ async def graphql(
         execution_context_class,
     )
 
-    if isawaitable(result):
+    if iscoroutine(result):
         return await cast(Awaitable[ExecutionResult], result)
 
     return cast(ExecutionResult, result)
@@ -123,7 +122,7 @@ def graphql_sync(
     )
 
     # Assert that the execution was synchronous.
-    if isawaitable(result):
+    if iscoroutine(result):
         ensure_future(cast(Awaitable[ExecutionResult], result)).cancel()
         raise RuntimeError("GraphQL execution failed to complete synchronously.")
 

--- a/src/graphql/pyutils/event_emitter.py
+++ b/src/graphql/pyutils/event_emitter.py
@@ -1,7 +1,6 @@
 from typing import cast, Callable, Dict, List, Optional
 
-from asyncio import AbstractEventLoop, Queue, ensure_future
-from inspect import isawaitable
+from asyncio import AbstractEventLoop, Queue, ensure_future, iscoroutine
 
 from collections import defaultdict
 
@@ -32,7 +31,7 @@ class EventEmitter:
             return False
         for listener in listeners:
             result = listener(*args, **kwargs)
-            if isawaitable(result):
+            if iscoroutine(result):
                 ensure_future(result, loop=self.loop)
         return True
 

--- a/src/graphql/subscription/map_async_iterator.py
+++ b/src/graphql/subscription/map_async_iterator.py
@@ -1,6 +1,6 @@
-from asyncio import Event, ensure_future, Future, wait
+from asyncio import Event, ensure_future, Future, wait, iscoroutine
 from concurrent.futures import FIRST_COMPLETED
-from inspect import isasyncgen, isawaitable
+from inspect import isasyncgen
 from typing import AsyncIterable, Callable, Set
 
 __all__ = ["MapAsyncIterator"]
@@ -62,7 +62,7 @@ class MapAsyncIterator:
                 value = anext.result()
                 result = self.callback(value)
 
-        return await result if isawaitable(result) else result
+        return await result if iscoroutine(result) else result
 
     async def athrow(self, type_, value=None, traceback=None):
         if not self.is_closed:

--- a/src/graphql/subscription/subscribe.py
+++ b/src/graphql/subscription/subscribe.py
@@ -1,4 +1,4 @@
-from inspect import isawaitable
+from asyncio import iscoroutine
 from typing import Any, AsyncIterable, AsyncIterator, Awaitable, Dict, Union, cast
 
 from ..error import GraphQLError, located_error
@@ -81,7 +81,7 @@ async def subscribe(
             operation_name,
             field_resolver,
         )
-        return await result if isawaitable(result) else result  # type: ignore
+        return await result if iscoroutine(result) else result  # type: ignore
 
     return MapAsyncIterator(result_or_stream, map_source_to_response)
 
@@ -162,7 +162,7 @@ async def create_source_event_stream(
     result = context.resolve_field_value_or_error(
         field_def, field_nodes, resolve_fn, root_value, info
     )
-    event_stream = await cast(Awaitable, result) if isawaitable(result) else result
+    event_stream = await cast(Awaitable, result) if iscoroutine(result) else result
     # If `event_stream` is an Error, rethrow a located error.
     if isinstance(event_stream, Exception):
         raise located_error(event_stream, field_nodes, path.as_list())

--- a/tests/execution/test_nonnull.py
+++ b/tests/execution/test_nonnull.py
@@ -1,5 +1,5 @@
 import re
-from inspect import isawaitable
+from asyncio import iscoroutine
 
 from pytest import mark  # type: ignore
 
@@ -107,7 +107,7 @@ def patch(data):
 
 async def execute_sync_and_async(query, root_value):
     sync_result = execute_query(query, root_value)
-    if isawaitable(sync_result):
+    if iscoroutine(sync_result):
         sync_result = await sync_result
     async_result = await execute_query(patch(query), root_value)
 

--- a/tests/execution/test_sync.py
+++ b/tests/execution/test_sync.py
@@ -1,4 +1,4 @@
-from inspect import isawaitable
+from asyncio import iscoroutine
 from typing import Awaitable, cast
 
 from pytest import mark, raises  # type: ignore
@@ -55,7 +55,7 @@ def describe_execute_synchronously_when_possible():
     async def returns_a_promise_if_any_field_is_asynchronous():
         doc = "query Example { syncField, asyncField }"
         result = execute(schema, parse(doc), "rootValue")
-        assert isawaitable(result)
+        assert iscoroutine(result)
         result = cast(Awaitable, result)
         assert await result == (
             {"syncField": "rootValue", "asyncField": "rootValue"},


### PR DESCRIPTION
R.e. the performance issues seen here: https://github.com/graphql-python/graphql-core-next/issues/54

Long term, it seems the best fix would be to minimize the usage of `iscoroutine`, in favor of inspecting and caching whether or not the function `iscoroutinefunction`. 

As a shorter term fix, this change switches form `inspect.isawaitable` to `asyncio.iscoroutine`. `inspect.isawaitable` is pure Python, while asyncio.iscoroutine is optimized in C and has a smarter type-cache. Reading through their implementations and comments, it isn't clear to me whether or not there is a semantic difference between the two, I'm relying on integration tests here to catch that. If there is a difference, I can update to use an early-exiting `or` to at least take the fast path when possible, assuming standard coroutines are the common case 🤞 