### PR TITLE
Make nodes extensible and weak-referencable

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,11 +191,10 @@ Design goals for the GraphQL-core 3 library are:
 
 Some restrictions (mostly in line with the design goals):
 
-* requires Python 3.6 or 3.7
+* requires Python 3.6 or newer
 * does not support some already deprecated methods and options of GraphQL.js
 * supports asynchronous operations only via async.io
   (does not support the additional executors in GraphQL-core)
-* the benchmarks have not yet been ported to Python
 
 
 ## Integration with other libraries and roadmap

--- a/src/graphql/execution/middleware.py
+++ b/src/graphql/execution/middleware.py
@@ -20,7 +20,7 @@ class MiddlewareManager:
     must be aware of this and check whether values are awaitable before awaiting them.
     """
 
-    __slots__ = "middlewares", "_middleware_resolvers", "_cached_resolvers"
+    __slots__ = "__weakref__", "__dict__", "middlewares", "_middleware_resolvers", "_cached_resolvers"
 
     _cached_resolvers: Dict[GraphQLFieldResolver, GraphQLFieldResolver]
     _middleware_resolvers: Optional[List[Callable]]

--- a/src/graphql/language/ast.py
+++ b/src/graphql/language/ast.py
@@ -72,7 +72,7 @@ class Token:
     Represents a range of characters represented by a lexical token within a Source.
     """
 
-    __slots__ = ("kind", "start", "end", "line", "column", "prev", "next", "value")
+    __slots__ = ("__dict__", "__weakref__", "kind", "start", "end", "line", "column", "prev", "next", "value")
 
     kind: TokenKind  # the kind of token
     start: int  # the character offset at which this Node begins
@@ -162,7 +162,7 @@ class Location:
     region of the source from which the AST derived.
     """
 
-    __slots__ = ("start", "end", "start_token", "end_token", "source")
+    __slots__ = ("__dict__", "__weakref__", "start", "end", "start_token", "end_token", "source")
 
     start: int  # character offset at which this Node begins
     end: int  # character offset at which this Node ends
@@ -214,7 +214,7 @@ class OperationType(Enum):
 class Node:
     """AST nodes"""
 
-    __slots__ = ("loc",)
+    __slots__ = ("__dict__", "__weakref__", "loc",)
 
     loc: Optional[Location]
 

--- a/src/graphql/language/ast.py
+++ b/src/graphql/language/ast.py
@@ -72,7 +72,7 @@ class Token:
     Represents a range of characters represented by a lexical token within a Source.
     """
 
-    __slots__ = ("__dict__", "__weakref__", "kind", "start", "end", "line", "column", "prev", "next", "value")
+    __slots__ = ("kind", "start", "end", "line", "column", "prev", "next", "value")
 
     kind: TokenKind  # the kind of token
     start: int  # the character offset at which this Node begins
@@ -162,7 +162,7 @@ class Location:
     region of the source from which the AST derived.
     """
 
-    __slots__ = ("__dict__", "__weakref__", "start", "end", "start_token", "end_token", "source")
+    __slots__ = ("start", "end", "start_token", "end_token", "source")
 
     start: int  # character offset at which this Node begins
     end: int  # character offset at which this Node ends

--- a/src/graphql/language/source.py
+++ b/src/graphql/language/source.py
@@ -6,7 +6,7 @@ __all__ = ["Source"]
 class Source:
     """A representation of source input to GraphQL."""
 
-    __slots__ = "body", "name", "location_offset"
+    __slots__ = "__weakref__", "__dict__", "body", "name", "location_offset"
 
     def __init__(
         self,

--- a/tests/language/test_ast.py
+++ b/tests/language/test_ast.py
@@ -83,16 +83,6 @@ def describe_token_class():
         assert token2 == token1
         assert token2 is not token1
 
-    def can_weakref():
-        token = Token(TokenKind.NAME, 1, 2, 1, 2, value="test")
-        wr = weakref.ref(token)  # That this works is 90% of the test
-        assert wr() is token
-
-    def can_make_attrs():
-        token = Token(TokenKind.NAME, 1, 2, 1, 2, value="test")
-        token.__new_random_attr = "Hello!"  # That this works is 90% of the test
-        assert token.__new_random_attr == "Hello!"
-
 
 def describe_location_class():
     token1 = Token(TokenKind.NAME, 1, 2, 1, 2)
@@ -154,16 +144,6 @@ def describe_location_class():
         assert loc4 != loc1
         assert hash(loc4) != hash(loc1)
         assert hash(loc4) != hash(loc3)
-
-    def can_weakref():
-        loc = Location(token1, token2, source)
-        wr = weakref.ref(loc)  # That this works is 90% of the test
-        assert wr() is loc
-
-    def can_make_attrs():
-        loc = Location(token1, token2, source)
-        loc.__new_random_attr = "Hello!"  # That this works is 90% of the test
-        assert loc.__new_random_attr == "Hello!"
 
 
 def describe_node_class():

--- a/tests/language/test_ast.py
+++ b/tests/language/test_ast.py
@@ -1,4 +1,5 @@
 from copy import copy, deepcopy
+import weakref
 
 from graphql.language import Location, Node, Source, Token, TokenKind
 from graphql.pyutils import inspect
@@ -82,6 +83,16 @@ def describe_token_class():
         assert token2 == token1
         assert token2 is not token1
 
+    def can_weakref():
+        token = Token(TokenKind.NAME, 1, 2, 1, 2, value="test")
+        wr = weakref.ref(token)  # That this works is 90% of the test
+        assert wr() is token
+
+    def can_make_attrs():
+        token = Token(TokenKind.NAME, 1, 2, 1, 2, value="test")
+        token.__new_random_attr = "Hello!"  # That this works is 90% of the test
+        assert token.__new_random_attr == "Hello!"
+
 
 def describe_location_class():
     token1 = Token(TokenKind.NAME, 1, 2, 1, 2)
@@ -143,6 +154,16 @@ def describe_location_class():
         assert loc4 != loc1
         assert hash(loc4) != hash(loc1)
         assert hash(loc4) != hash(loc3)
+
+    def can_weakref():
+        loc = Location(token1, token2, source)
+        wr = weakref.ref(loc)  # That this works is 90% of the test
+        assert wr() is loc
+
+    def can_make_attrs():
+        loc = Location(token1, token2, source)
+        loc.__new_random_attr = "Hello!"  # That this works is 90% of the test
+        assert loc.__new_random_attr == "Hello!"
 
 
 def describe_node_class():
@@ -224,3 +245,13 @@ def describe_node_class():
 
     def provides_keys_as_class_attribute():
         assert SampleTestNode.keys == ["loc", "alpha", "beta"]
+
+    def can_weakref():
+        node = SampleTestNode(alpha=1, beta=2)
+        wr = weakref.ref(node)  # That this works is 90% of the test
+        assert wr() is node
+
+    def can_make_attrs():
+        node = SampleTestNode(alpha=1, beta=2)
+        node.__new_random_attr = "Hello!"  # That this works is 90% of the test
+        assert node.__new_random_attr == "Hello!"


### PR DESCRIPTION
Add standard dunder attributes to (almost) all instances of `__slots__`

Using the test suite as a benchmark, this change produced no noticeable slow down.

Closes #81