### PR TITLE
add rudimentary typing to default_field_resolver

### DIFF
--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -1161,7 +1161,7 @@ def default_type_resolver(
     return None
 
 
-def default_field_resolver(source, info, **args):
+def default_field_resolver(source: Any, info: GraphQLResolveInfo, **args: Any) -> Any:
     """Default field resolver.
 
     If a resolve function is not given, then a default resolve behavior is used which


### PR DESCRIPTION
It's me again with a type hints issue. I'm writing a custom field resolver:

```python
def custom_field_resolver(source: Any, info: GraphQLResolveInfo, **args: Any) -> Any:
    if info.field_name == "foo" and hasattr(source, "bar"):
        return source.bar
    return default_field_resolver(source, info, **args)


result = await graphql_execute(
    ...,
    field_resolver=custom_field_resolver,
)
```
and have `disallow_untyped_calls = True` in my `mypy` config. Running the type check yields
```
<mymod>.py:<line>: error: Call to untyped function "default_field_resolver" in typed context
```

I'd thus propose to add at least a rudimentary typing to `graphql.execute.default_field_resolver` for now. Once Python 3.6 and 3.7 are dropped, I suppose a better typing using protocols could be possible. 

Signed-off-by: oleg.hoefling <oleg.hoefling@gmail.com>