### PR TITLE
Fix method name in Visitor docstring

### DIFF
--- a/src/graphql/language/visitor.py
+++ b/src/graphql/language/visitor.py
@@ -127,7 +127,7 @@ class Visitor:
             # any other value: replace this node with the returned value
             return
 
-        def enter(self, node, key, parent, path, ancestors):
+        def leave(self, node, key, parent, path, ancestors):
             # The return value has the following meaning:
             # IDLE (None) or SKIP: no action
             # BREAK: stop visiting altogether


### PR DESCRIPTION
The docstring for the Visitor class describes the signatures for the `enter` and `leave` methods. However, it labels both of them as `enter`.