### PR TITLE
coerce str

### DIFF
--- a/src/graphql/type/scalars.py
+++ b/src/graphql/type/scalars.py
@@ -1,5 +1,5 @@
 from math import isfinite
-from typing import Any
+from typing import Any, Union
 
 from ..error import GraphQLError
 from ..pyutils import inspect, is_finite, is_integer, FrozenDict
@@ -60,8 +60,15 @@ def serialize_int(output_value: Any) -> int:
         )
     return num
 
+def _try_convert_str_to_int(s: str) -> Union[str, int]:
+    try:
+        return int(s)
+    except (ValueError, TypeError):
+        return s
 
 def coerce_int(input_value: Any) -> int:
+    if isinstance(input_value, str):
+        input_value = _try_convert_str_to_int(input_value)
     if not is_integer(input_value):
         raise GraphQLError(
             "Int cannot represent non-integer value: " + inspect(input_value)

--- a/tests/type/test_scalars.py
+++ b/tests/type/test_scalars.py
@@ -12,6 +12,7 @@ from graphql.type import (
     GraphQLBoolean,
     GraphQLID,
 )
+from graphql.type.scalars import coerce_int
 
 
 def describe_type_system_specified_scalar_types():
@@ -27,6 +28,7 @@ def describe_type_system_specified_scalar_types():
             assert _parse_value(1) == 1
             assert _parse_value(0) == 0
             assert _parse_value(-1) == -1
+            assert _parse_value("123") == 123
 
             _parse_value_raises(
                 9876504321,
@@ -44,7 +46,7 @@ def describe_type_system_specified_scalar_types():
             )
             _parse_value_raises(None, "Int cannot represent non-integer value: None")
             _parse_value_raises("", "Int cannot represent non-integer value: ''")
-            _parse_value_raises("123", "Int cannot represent non-integer value: '123'")
+            _parse_value_raises("abc", "Int cannot represent non-integer value: 'abc'")
             _parse_value_raises(False, "Int cannot represent non-integer value: False")
             _parse_value_raises(True, "Int cannot represent non-integer value: True")
             _parse_value_raises([1], "Int cannot represent non-integer value: [1]")


### PR DESCRIPTION
It's convenient for frontend to pass `str` as some  value of `Int`  type,  maybe it's too strict to reject valid  **int str** .

By the way, I tried to upgrade a project from `graphene 2` to `graphene 3` and found that in `graphene 2`  str would coerce to int correctly while `graphene 3` just throws the error `Int cannot represent non-integer value: `, which I think is caused by the `coerce_int` function here.
