### PR TITLE
Convert all FrozenList type usages to Sequence

### DIFF
--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -968,9 +968,9 @@ class ExecutionContext:
                         raise invalid_return_type_error(
                             return_type, result, field_nodes
                         )
-                    return self.collect_and_execute_subfields(
+                    return self.collect_and_execute_subfields(  # type: ignore
                         return_type, field_nodes, path, result
-                    )  # type: ignore
+                    )
 
                 return collect_and_execute_subfields_async()
 

--- a/src/graphql/execution/values.py
+++ b/src/graphql/execution/values.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional, Union, cast
+from typing import Any, Callable, Dict, List, Optional, Union, cast, Sequence
 
 from ..error import GraphQLError
 from ..language import (
@@ -16,7 +16,7 @@ from ..language import (
     VariableNode,
     print_ast,
 )
-from ..pyutils import inspect, print_path_list, FrozenList, Undefined
+from ..pyutils import inspect, print_path_list, Undefined
 from ..type import (
     GraphQLDirective,
     GraphQLField,
@@ -37,7 +37,7 @@ CoercedVariableValues = Union[List[GraphQLError], Dict[str, Any]]
 
 def get_variable_values(
     schema: GraphQLSchema,
-    var_def_nodes: FrozenList[VariableDefinitionNode],
+    var_def_nodes: Sequence[VariableDefinitionNode],
     inputs: Dict[str, Any],
     max_errors: Optional[int] = None,
 ) -> CoercedVariableValues:
@@ -71,7 +71,7 @@ def get_variable_values(
 
 def coerce_variable_values(
     schema: GraphQLSchema,
-    var_def_nodes: FrozenList[VariableDefinitionNode],
+    var_def_nodes: Sequence[VariableDefinitionNode],
     inputs: Dict[str, Any],
     on_error: Callable[[GraphQLError], None],
 ) -> Dict[str, Any]:

--- a/src/graphql/language/ast.py
+++ b/src/graphql/language/ast.py
@@ -1,6 +1,6 @@
 from copy import copy, deepcopy
 from enum import Enum
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union, Sequence
 
 from .source import Source
 from .token_kind import TokenKind
@@ -292,7 +292,7 @@ class NameNode(Node):
 class DocumentNode(Node):
     __slots__ = ("definitions",)
 
-    definitions: FrozenList["DefinitionNode"]
+    definitions: Sequence["DefinitionNode"]
 
 
 class DefinitionNode(Node):
@@ -303,8 +303,8 @@ class ExecutableDefinitionNode(DefinitionNode):
     __slots__ = "name", "directives", "variable_definitions", "selection_set"
 
     name: Optional[NameNode]
-    directives: FrozenList["DirectiveNode"]
-    variable_definitions: FrozenList["VariableDefinitionNode"]
+    directives: Sequence["DirectiveNode"]
+    variable_definitions: Sequence["VariableDefinitionNode"]
     selection_set: "SelectionSetNode"
 
 
@@ -320,19 +320,19 @@ class VariableDefinitionNode(Node):
     variable: "VariableNode"
     type: "TypeNode"
     default_value: Optional["ValueNode"]
-    directives: FrozenList["DirectiveNode"]
+    directives: Sequence["DirectiveNode"]
 
 
 class SelectionSetNode(Node):
     __slots__ = ("selections",)
 
-    selections: FrozenList["SelectionNode"]
+    selections: Sequence["SelectionNode"]
 
 
 class SelectionNode(Node):
     __slots__ = ("directives",)
 
-    directives: FrozenList["DirectiveNode"]
+    directives: Sequence["DirectiveNode"]
 
 
 class FieldNode(SelectionNode):
@@ -340,7 +340,7 @@ class FieldNode(SelectionNode):
 
     alias: Optional[NameNode]
     name: NameNode
-    arguments: FrozenList["ArgumentNode"]
+    arguments: Sequence["ArgumentNode"]
     selection_set: Optional[SelectionSetNode]
 
 
@@ -425,13 +425,13 @@ class EnumValueNode(ValueNode):
 class ListValueNode(ValueNode):
     __slots__ = ("values",)
 
-    values: FrozenList[ValueNode]
+    values: Sequence[ValueNode]
 
 
 class ObjectValueNode(ValueNode):
     __slots__ = ("fields",)
 
-    fields: FrozenList["ObjectFieldNode"]
+    fields: Sequence["ObjectFieldNode"]
 
 
 class ObjectFieldNode(Node):
@@ -448,7 +448,7 @@ class DirectiveNode(Node):
     __slots__ = "name", "arguments"
 
     name: NameNode
-    arguments: FrozenList[ArgumentNode]
+    arguments: Sequence[ArgumentNode]
 
 
 # Type Reference
@@ -487,8 +487,8 @@ class SchemaDefinitionNode(TypeSystemDefinitionNode):
     __slots__ = "description", "directives", "operation_types"
 
     description: Optional[StringValueNode]
-    directives: FrozenList[DirectiveNode]
-    operation_types: FrozenList["OperationTypeDefinitionNode"]
+    directives: Sequence[DirectiveNode]
+    operation_types: Sequence["OperationTypeDefinitionNode"]
 
 
 class OperationTypeDefinitionNode(Node):
@@ -506,7 +506,7 @@ class TypeDefinitionNode(TypeSystemDefinitionNode):
 
     description: Optional[StringValueNode]
     name: NameNode
-    directives: FrozenList[DirectiveNode]
+    directives: Sequence[DirectiveNode]
 
 
 class ScalarTypeDefinitionNode(TypeDefinitionNode):
@@ -516,8 +516,8 @@ class ScalarTypeDefinitionNode(TypeDefinitionNode):
 class ObjectTypeDefinitionNode(TypeDefinitionNode):
     __slots__ = "interfaces", "fields"
 
-    interfaces: FrozenList[NamedTypeNode]
-    fields: FrozenList["FieldDefinitionNode"]
+    interfaces: Sequence[NamedTypeNode]
+    fields: Sequence["FieldDefinitionNode"]
 
 
 class FieldDefinitionNode(DefinitionNode):
@@ -525,8 +525,8 @@ class FieldDefinitionNode(DefinitionNode):
 
     description: Optional[StringValueNode]
     name: NameNode
-    directives: FrozenList[DirectiveNode]
-    arguments: FrozenList["InputValueDefinitionNode"]
+    directives: Sequence[DirectiveNode]
+    arguments: Sequence["InputValueDefinitionNode"]
     type: TypeNode
 
 
@@ -535,7 +535,7 @@ class InputValueDefinitionNode(DefinitionNode):
 
     description: Optional[StringValueNode]
     name: NameNode
-    directives: FrozenList[DirectiveNode]
+    directives: Sequence[DirectiveNode]
     type: TypeNode
     default_value: Optional[ValueNode]
 
@@ -543,20 +543,20 @@ class InputValueDefinitionNode(DefinitionNode):
 class InterfaceTypeDefinitionNode(TypeDefinitionNode):
     __slots__ = "fields", "interfaces"
 
-    fields: FrozenList["FieldDefinitionNode"]
-    interfaces: FrozenList[NamedTypeNode]
+    fields: Sequence["FieldDefinitionNode"]
+    interfaces: Sequence[NamedTypeNode]
 
 
 class UnionTypeDefinitionNode(TypeDefinitionNode):
     __slots__ = ("types",)
 
-    types: FrozenList[NamedTypeNode]
+    types: Sequence[NamedTypeNode]
 
 
 class EnumTypeDefinitionNode(TypeDefinitionNode):
     __slots__ = ("values",)
 
-    values: FrozenList["EnumValueDefinitionNode"]
+    values: Sequence["EnumValueDefinitionNode"]
 
 
 class EnumValueDefinitionNode(TypeDefinitionNode):
@@ -566,7 +566,7 @@ class EnumValueDefinitionNode(TypeDefinitionNode):
 class InputObjectTypeDefinitionNode(TypeDefinitionNode):
     __slots__ = ("fields",)
 
-    fields: FrozenList[InputValueDefinitionNode]
+    fields: Sequence[InputValueDefinitionNode]
 
 
 # Directive Definitions
@@ -577,9 +577,9 @@ class DirectiveDefinitionNode(TypeSystemDefinitionNode):
 
     description: Optional[StringValueNode]
     name: NameNode
-    arguments: FrozenList[InputValueDefinitionNode]
+    arguments: Sequence[InputValueDefinitionNode]
     repeatable: bool
-    locations: FrozenList[NameNode]
+    locations: Sequence[NameNode]
 
 
 # Type System Extensions
@@ -588,8 +588,8 @@ class DirectiveDefinitionNode(TypeSystemDefinitionNode):
 class SchemaExtensionNode(Node):
     __slots__ = "directives", "operation_types"
 
-    directives: FrozenList[DirectiveNode]
-    operation_types: FrozenList[OperationTypeDefinitionNode]
+    directives: Sequence[DirectiveNode]
+    operation_types: Sequence[OperationTypeDefinitionNode]
 
 
 # Type Extensions
@@ -599,7 +599,7 @@ class TypeExtensionNode(TypeSystemDefinitionNode):
     __slots__ = "name", "directives"
 
     name: NameNode
-    directives: FrozenList[DirectiveNode]
+    directives: Sequence[DirectiveNode]
 
 
 TypeSystemExtensionNode = Union[SchemaExtensionNode, TypeExtensionNode]
@@ -612,30 +612,30 @@ class ScalarTypeExtensionNode(TypeExtensionNode):
 class ObjectTypeExtensionNode(TypeExtensionNode):
     __slots__ = "interfaces", "fields"
 
-    interfaces: FrozenList[NamedTypeNode]
-    fields: FrozenList[FieldDefinitionNode]
+    interfaces: Sequence[NamedTypeNode]
+    fields: Sequence[FieldDefinitionNode]
 
 
 class InterfaceTypeExtensionNode(TypeExtensionNode):
     __slots__ = "interfaces", "fields"
 
-    interfaces: FrozenList[NamedTypeNode]
-    fields: FrozenList[FieldDefinitionNode]
+    interfaces: Sequence[NamedTypeNode]
+    fields: Sequence[FieldDefinitionNode]
 
 
 class UnionTypeExtensionNode(TypeExtensionNode):
     __slots__ = ("types",)
 
-    types: FrozenList[NamedTypeNode]
+    types: Sequence[NamedTypeNode]
 
 
 class EnumTypeExtensionNode(TypeExtensionNode):
     __slots__ = ("values",)
 
-    values: FrozenList[EnumValueDefinitionNode]
+    values: Sequence[EnumValueDefinitionNode]
 
 
 class InputObjectTypeExtensionNode(TypeExtensionNode):
     __slots__ = ("fields",)
 
-    fields: FrozenList[InputValueDefinitionNode]
+    fields: Sequence[InputValueDefinitionNode]

--- a/src/graphql/pyutils/undefined.py
+++ b/src/graphql/pyutils/undefined.py
@@ -26,8 +26,7 @@ class UndefinedType(ValueError):
 
 # Used to indicate undefined or invalid values (like "undefined" in JavaScript):
 Undefined = UndefinedType()
-
-Undefined.__doc__ = """Symbol for undefined values
+"""Symbol for undefined values
 
 This singleton object is used to describe undefined or invalid  values.
 It can be used in places where you would use ``undefined`` in GraphQL.js.

--- a/src/graphql/type/definition.py
+++ b/src/graphql/type/definition.py
@@ -14,6 +14,7 @@ from typing import (
     Union,
     cast,
     overload,
+    Sequence,
 )
 
 from ..error import GraphQLError
@@ -196,7 +197,7 @@ class GraphQLNamedType(GraphQLType):
     description: Optional[str]
     extensions: Optional[Dict[str, Any]]
     ast_node: Optional[TypeDefinitionNode]
-    extension_ast_nodes: Optional[FrozenList[TypeExtensionNode]]
+    extension_ast_nodes: Optional[Sequence[TypeExtensionNode]]
 
     def __init__(
         self,
@@ -320,7 +321,7 @@ class GraphQLScalarType(GraphQLNamedType):
 
     specified_by_url: Optional[str]
     ast_node: Optional[ScalarTypeDefinitionNode]
-    extension_ast_nodes: Optional[FrozenList[ScalarTypeExtensionNode]]
+    extension_ast_nodes: Optional[Sequence[ScalarTypeExtensionNode]]
 
     def __init__(
         self,
@@ -690,7 +691,7 @@ class GraphQLObjectType(GraphQLNamedType):
 
     is_type_of: Optional[GraphQLIsTypeOfFn]
     ast_node: Optional[ObjectTypeDefinitionNode]
-    extension_ast_nodes: Optional[FrozenList[ObjectTypeExtensionNode]]
+    extension_ast_nodes: Optional[Sequence[ObjectTypeExtensionNode]]
 
     def __init__(
         self,
@@ -810,7 +811,7 @@ class GraphQLInterfaceType(GraphQLNamedType):
 
     resolve_type: Optional[GraphQLTypeResolver]
     ast_node: Optional[InterfaceTypeDefinitionNode]
-    extension_ast_nodes: Optional[FrozenList[InterfaceTypeExtensionNode]]
+    extension_ast_nodes: Optional[Sequence[InterfaceTypeExtensionNode]]
 
     def __init__(
         self,
@@ -933,7 +934,7 @@ class GraphQLUnionType(GraphQLNamedType):
 
     resolve_type: Optional[GraphQLTypeResolver]
     ast_node: Optional[UnionTypeDefinitionNode]
-    extension_ast_nodes: Optional[FrozenList[UnionTypeExtensionNode]]
+    extension_ast_nodes: Optional[Sequence[UnionTypeExtensionNode]]
 
     def __init__(
         self,
@@ -1039,7 +1040,7 @@ class GraphQLEnumType(GraphQLNamedType):
 
     values: GraphQLEnumValueMap
     ast_node: Optional[EnumTypeDefinitionNode]
-    extension_ast_nodes: Optional[FrozenList[EnumTypeExtensionNode]]
+    extension_ast_nodes: Optional[Sequence[EnumTypeExtensionNode]]
 
     def __init__(
         self,
@@ -1267,7 +1268,7 @@ class GraphQLInputObjectType(GraphQLNamedType):
     """
 
     ast_node: Optional[InputObjectTypeDefinitionNode]
-    extension_ast_nodes: Optional[FrozenList[InputObjectTypeExtensionNode]]
+    extension_ast_nodes: Optional[Sequence[InputObjectTypeExtensionNode]]
 
     def __init__(
         self,

--- a/src/graphql/type/directives.py
+++ b/src/graphql/type/directives.py
@@ -1,4 +1,4 @@
-from typing import Any, Collection, Dict, List, Optional, cast
+from typing import Any, Collection, Dict, List, Optional, cast, Sequence
 
 from ..language import ast, DirectiveLocation
 from ..pyutils import inspect, is_description, FrozenList
@@ -211,7 +211,7 @@ GraphQLSpecifiedByDirective = GraphQLDirective(
 )
 
 
-specified_directives: FrozenList[GraphQLDirective] = FrozenList(
+specified_directives: Sequence[GraphQLDirective] = FrozenList(
     [
         GraphQLIncludeDirective,
         GraphQLSkipDirective,
@@ -219,7 +219,7 @@ specified_directives: FrozenList[GraphQLDirective] = FrozenList(
         GraphQLSpecifiedByDirective,
     ]
 )
-specified_directives.__doc__ = """The full list of specified directives."""
+"""The full list of specified directives."""
 
 
 def is_specified_directive(directive: GraphQLDirective) -> bool:

--- a/src/graphql/type/introspection.py
+++ b/src/graphql/type/introspection.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Mapping, Union
 
 from .definition import (
     GraphQLArgument,
@@ -506,7 +507,9 @@ TypeNameMetaFieldDef = GraphQLField(
 
 # Since double underscore names are subject to name mangling in Python,
 # the introspection classes are best imported via this dictionary:
-introspection_types = FrozenDict(
+introspection_types: Mapping[
+    str, Union[GraphQLNamedType, GraphQLObjectType]
+] = FrozenDict(
     {
         "__Schema": __Schema,
         "__Directive": __Directive,
@@ -518,7 +521,7 @@ introspection_types = FrozenDict(
         "__TypeKind": __TypeKind,
     }
 )
-introspection_types.__doc__ = """A dictionary containing all introspection types."""
+"""A dictionary containing all introspection types."""
 
 
 def is_introspection_type(type_: GraphQLNamedType) -> bool:

--- a/src/graphql/type/scalars.py
+++ b/src/graphql/type/scalars.py
@@ -1,5 +1,5 @@
 from math import isfinite
-from typing import Any
+from typing import Any, Mapping
 
 from ..error import GraphQLError
 from ..pyutils import inspect, is_finite, is_integer, FrozenDict
@@ -275,7 +275,7 @@ GraphQLID = GraphQLScalarType(
 )
 
 
-specified_scalar_types: FrozenDict[str, GraphQLScalarType] = FrozenDict(
+specified_scalar_types: Mapping[str, GraphQLScalarType] = FrozenDict(
     {
         type_.name: type_
         for type_ in (

--- a/src/graphql/type/schema.py
+++ b/src/graphql/type/schema.py
@@ -8,6 +8,7 @@ from typing import (
     Set,
     Union,
     cast,
+    Sequence,
 )
 
 from ..error import GraphQLError
@@ -93,11 +94,11 @@ class GraphQLSchema:
     mutation_type: Optional[GraphQLObjectType]
     subscription_type: Optional[GraphQLObjectType]
     type_map: TypeMap
-    directives: FrozenList[GraphQLDirective]
+    directives: Sequence[GraphQLDirective]
     description: Optional[str]
     extensions: Optional[Dict[str, Any]]
     ast_node: Optional[ast.SchemaDefinitionNode]
-    extension_ast_nodes: Optional[FrozenList[ast.SchemaExtensionNode]]
+    extension_ast_nodes: Optional[Sequence[ast.SchemaExtensionNode]]
 
     _implementations_map: Dict[str, InterfaceImplementations]
     _sub_type_map: Dict[str, Set[str]]
@@ -171,7 +172,7 @@ class GraphQLSchema:
         self.extensions = extensions
         self.ast_node = ast_node
         self.extension_ast_nodes = (
-            cast(FrozenList[ast.SchemaExtensionNode], extension_ast_nodes)
+            cast(Sequence[ast.SchemaExtensionNode], extension_ast_nodes)
             if extension_ast_nodes
             else None
         )
@@ -183,7 +184,7 @@ class GraphQLSchema:
         self.directives = (
             specified_directives
             if directives is None
-            else cast(FrozenList[GraphQLDirective], directives)
+            else cast(Sequence[GraphQLDirective], directives)
         )
 
         # To preserve order of user-provided types, we add first to add them to

--- a/src/graphql/utilities/find_breaking_changes.py
+++ b/src/graphql/utilities/find_breaking_changes.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from operator import attrgetter
-from typing import Any, Dict, List, NamedTuple, Union, cast
+from typing import Any, Dict, List, NamedTuple, Union, cast, Sequence
 
 from ..language import print_ast, visit, ObjectValueNode, Visitor
 from ..pyutils import inspect, FrozenList, Undefined
@@ -580,7 +580,7 @@ class ListDiff(NamedTuple):
     persisted: List
 
 
-def list_diff(old_list: List, new_list: List) -> ListDiff:
+def list_diff(old_list: Sequence, new_list: Sequence) -> ListDiff:
     """Get differences between two lists of named items."""
     added = []
     persisted = []

--- a/src/graphql/utilities/lexicographic_sort_schema.py
+++ b/src/graphql/utilities/lexicographic_sort_schema.py
@@ -1,7 +1,7 @@
-from typing import Dict, List, Optional, Tuple, Union, cast
+from typing import Dict, List, Optional, Tuple, Union, cast, Sequence
 
 from ..language import DirectiveLocation
-from ..pyutils import inspect, FrozenList
+from ..pyutils import inspect
 from ..type import (
     GraphQLArgument,
     GraphQLDirective,
@@ -97,7 +97,7 @@ def lexicographic_sort_schema(schema: GraphQLSchema) -> GraphQLSchema:
             for name, field in sorted(fields_map.items())
         }
 
-    def sort_types(arr: FrozenList[GraphQLNamedType]) -> List[GraphQLNamedType]:
+    def sort_types(arr: Sequence[GraphQLNamedType]) -> List[GraphQLNamedType]:
         return [
             replace_named_type(type_) for type_ in sorted(arr, key=sort_by_name_key)
         ]

--- a/src/graphql/validation/specified_rules.py
+++ b/src/graphql/validation/specified_rules.py
@@ -1,4 +1,4 @@
-from typing import Type
+from typing import Type, Sequence
 
 from ..pyutils import FrozenList
 
@@ -101,7 +101,7 @@ __all__ = ["specified_rules", "specified_sdl_rules"]
 # The order of the rules in this list has been adjusted to lead to the
 # most clear output when encountering multiple validation errors.
 
-specified_rules: FrozenList[Type[ASTValidationRule]] = FrozenList(
+specified_rules: Sequence[Type[ASTValidationRule]] = FrozenList(
     [
         ExecutableDefinitionsRule,
         UniqueOperationNamesRule,
@@ -131,14 +131,14 @@ specified_rules: FrozenList[Type[ASTValidationRule]] = FrozenList(
         UniqueInputFieldNamesRule,
     ]
 )
-specified_rules.__doc__ = """\
-    This list includes all validation rules defined by the GraphQL spec.
+"""
+This list includes all validation rules defined by the GraphQL spec.
 
-    The order of the rules in this list has been adjusted to lead to the
-    most clear output when encountering multiple validation errors.
-    """
+The order of the rules in this list has been adjusted to lead to the
+most clear output when encountering multiple validation errors.
+"""
 
-specified_sdl_rules: FrozenList[Type[ASTValidationRule]] = FrozenList(
+specified_sdl_rules: Sequence[Type[ASTValidationRule]] = FrozenList(
     [
         LoneSchemaDefinitionRule,
         UniqueOperationTypesRule,
@@ -156,8 +156,8 @@ specified_sdl_rules: FrozenList[Type[ASTValidationRule]] = FrozenList(
         ProvidedRequiredArgumentsOnDirectivesRule,
     ]
 )
-specified_sdl_rules.__doc__ = """\
-    This list includes all rules for validating SDL.
+"""
+This list includes all rules for validating SDL.
 
-    For internal use only.
-    """
+For internal use only.
+"""

--- a/tests/language/test_visitor.py
+++ b/tests/language/test_visitor.py
@@ -982,13 +982,14 @@ def describe_support_for_custom_ast_nodes():
 
     custom_selection_set = cast(FieldNode, custom_ast.definitions[0]).selection_set
     assert custom_selection_set is not None
-    custom_selection_set.selections = custom_selection_set.selections + [
+    custom_selection_set.selections = [
+        *custom_selection_set.selections,
         CustomFieldNode(
             name=NameNode(value="b"),
             selection_set=SelectionSetNode(
                 selections=CustomFieldNode(name=NameNode(value="c"))
             ),
-        )
+        ),
     ]
 
     def does_not_traverse_unknown_node_kinds():


### PR DESCRIPTION
Purely structural change, no adjustment to behavior. Simply replacing all usages of FrozenList in type definitions such that FrozenList is effectively an implementation detail (to be swapped in a subsequent change)

Part 1 of https://github.com/graphql-python/graphql-core/issues/112