### PR TITLE
validation.validate slowness

### DIFF
--- a/src/graphql/language/ast.py
+++ b/src/graphql/language/ast.py
@@ -221,15 +221,17 @@ class Node:
     """AST nodes"""
 
     # allow custom attributes and weak references (not used internally)
-    __slots__ = "__dict__", "__weakref__", "loc"
+    __slots__ = "__dict__", "__weakref__", "loc", "_hash"
 
     loc: Optional[Location]
 
     kind: str = "ast"  # the kind of the node as a snake_case string
     keys = ["loc"]  # the names of the attributes of this node
 
+
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the node with the given keyword arguments."""
+        self._hash = None
         for key in self.keys:
             value = kwargs.get(key)
             if isinstance(value, list) and not isinstance(value, FrozenList):
@@ -250,7 +252,10 @@ class Node:
         )
 
     def __hash__(self) -> int:
-        return hash(tuple(getattr(self, key) for key in self.keys))
+        if self._hash is None:
+            self._hash = hash(tuple(getattr(self, key) for key in self.keys))
+
+        return self._hash
 
     def __copy__(self) -> "Node":
         """Create a shallow copy of the node."""

--- a/src/graphql/validation/rules/__init__.py
+++ b/src/graphql/validation/rules/__init__.py
@@ -17,6 +17,7 @@ class ASTValidationRule(Visitor):
     context: ASTValidationContext
 
     def __init__(self, context: ASTValidationContext):
+        super().__init__()
         self.context = context
 
     def report_error(self, error: GraphQLError) -> None:

--- a/src/graphql/validation/validation_context.py
+++ b/src/graphql/validation/validation_context.py
@@ -46,6 +46,7 @@ class VariableUsageVisitor(Visitor):
     usages: List[VariableUsage]
 
     def __init__(self, type_info: TypeInfo):
+        super().__init__()
         self.usages = []
         self._append_usage = self.usages.append
         self._type_info = type_info


### PR DESCRIPTION
Small scratch script demonstrating validation.validate slowness.

You can run by installing graphql-core in a venv, then running scratch.py. Personally,
I then run it through gprof2dot for visualisation

Demonstration of #116 

By memoising the various visitors, I got the runtime proportion down from ~85% to ~70%. Removing the variable checks removed another 10%. I'm not sure how safe either of these were.