### PR TITLE
Set enum value values to value names in build_client_schema

### DIFF
--- a/src/graphql/utilities/build_client_schema.py
+++ b/src/graphql/utilities/build_client_schema.py
@@ -175,6 +175,7 @@ def build_client_schema(
             description=enum_introspection.get("description"),
             values={
                 value_introspect["name"]: GraphQLEnumValue(
+                    value=value_introspect.get("name"),
                     description=value_introspect.get("description"),
                     deprecation_reason=value_introspect.get("deprecationReason"),
                 )

--- a/src/graphql/utilities/build_client_schema.py
+++ b/src/graphql/utilities/build_client_schema.py
@@ -175,7 +175,7 @@ def build_client_schema(
             description=enum_introspection.get("description"),
             values={
                 value_introspect["name"]: GraphQLEnumValue(
-                    value=value_introspect.get("name"),
+                    value=value_introspect["name"],
                     description=value_introspect.get("description"),
                     deprecation_reason=value_introspect.get("deprecationReason"),
                 )

--- a/tests/utilities/test_build_client_schema.py
+++ b/tests/utilities/test_build_client_schema.py
@@ -382,28 +382,29 @@ def describe_type_system_build_schema_from_introspection():
         # It's also an Enum type on the client.
         client_food_enum = assert_enum_type(client_schema.get_type("Food"))
 
-        # Client types do not get server-only values, so they are set to None
-        # rather than using the integers defined in the "server" schema.
+        # Client types do not get server-only values, so they are set to the
+        # names of the enum values rather than using the integers defined in
+        # the "server" schema.
         values = {
             name: value.to_kwargs() for name, value in client_food_enum.values.items()
         }
         assert values == {
             "VEGETABLES": {
-                "value": None,
+                "value": "VEGETABLES",
                 "description": "Foods that are vegetables.",
                 "deprecation_reason": None,
                 "extensions": None,
                 "ast_node": None,
             },
             "FRUITS": {
-                "value": None,
+                "value": "FRUITS",
                 "description": None,
                 "deprecation_reason": None,
                 "extensions": None,
                 "ast_node": None,
             },
             "OILS": {
-                "value": None,
+                "value": "OILS",
                 "description": None,
                 "deprecation_reason": "Too fatty.",
                 "extensions": None,


### PR DESCRIPTION
This makes it consistent with build_ast_schema (see commit
2a1953f8563135b85bd7b0ecf78e7630484ccdb2), and ensures that default enum
values are reflected in schemas built from introspection when using
`gql` (the introspection version of
https://github.com/graphql-python/graphql-core/issues/111).