### PR TITLE
Add simple execute benchmarks for both sync and async execution

### DIFF
--- a/tests/benchmarks/test_execution_async.py
+++ b/tests/benchmarks/test_execution_async.py
@@ -1,0 +1,50 @@
+import asyncio
+from graphql import (
+    GraphQLSchema,
+    GraphQLObjectType,
+    GraphQLField,
+    GraphQLString,
+    graphql,
+)
+
+
+user = GraphQLObjectType(
+    name="User",
+    fields={
+        "id": GraphQLField(GraphQLString),
+        "name": GraphQLField(GraphQLString),
+    },
+)
+
+
+async def resolve_user(obj, info):
+    return {
+        "id": "1",
+        "name": "Sarah",
+    }
+
+
+schema = GraphQLSchema(
+    query=GraphQLObjectType(
+        name="Query",
+        fields={
+            "user": GraphQLField(
+                user,
+                resolve=resolve_user,
+            )
+        },
+    )
+)
+
+
+def test_execute_basic_async(benchmark):
+    result = benchmark(
+        lambda: asyncio.run(graphql(schema, "query { user { id, name }}"))
+    )
+    assert not result.errors
+    assert result.data == {
+        "user": {
+            "id": "1",
+            "name": "Sarah",
+        },
+    }

--- a/tests/benchmarks/test_execution_sync.py
+++ b/tests/benchmarks/test_execution_sync.py
@@ -1,0 +1,47 @@
+from graphql import (
+    GraphQLSchema,
+    GraphQLObjectType,
+    GraphQLField,
+    GraphQLString,
+    graphql_sync,
+)
+
+
+user = GraphQLObjectType(
+    name="User",
+    fields={
+        "id": GraphQLField(GraphQLString),
+        "name": GraphQLField(GraphQLString),
+    },
+)
+
+
+def resolve_user(obj, info):
+    return {
+        "id": "1",
+        "name": "Sarah",
+    }
+
+
+schema = GraphQLSchema(
+    query=GraphQLObjectType(
+        name="Query",
+        fields={
+            "user": GraphQLField(
+                user,
+                resolve=resolve_user,
+            )
+        },
+    )
+)
+
+
+def test_execute_basic_sync(benchmark):
+    result = benchmark(lambda: graphql_sync(schema, "query { user { id, name }}"))
+    assert not result.errors
+    assert result.data == {
+        "user": {
+            "id": "1",
+            "name": "Sarah",
+        },
+    }


### PR DESCRIPTION
This PR adds 2 new benchmarks for to check execution both in a sync and async context.

Running these benchmarks has highlighted that the async execution in graphql-core is significantly slower than the sync execution (~70% slower). @Cito any idea why that might be? It's much higher than I would have expected.

<img width="1428" alt="CleanShot 2021-10-13 at 20 50 59@2x" src="https://user-images.githubusercontent.com/691952/137203533-2284b20f-bb44-41c2-91cb-a96574788d2b.png">
