### PR TITLE
Cache node hashing

### DIFF
--- a/src/graphql/language/ast.py
+++ b/src/graphql/language/ast.py
@@ -259,6 +259,10 @@ class Node:
             self._hash = hash(tuple(getattr(self, key) for key in self.keys))
         return self._hash
 
+    def __setattr__(self, key, value):
+        object.__setattr__(self, "_hash", None)
+        super().__setattr__(key, value)
+
     def __copy__(self) -> "Node":
         """Create a shallow copy of the node."""
         return self.__class__(**{key: getattr(self, key) for key in self.keys})

--- a/src/graphql/language/ast.py
+++ b/src/graphql/language/ast.py
@@ -226,7 +226,7 @@ class Node:
     """AST nodes"""
 
     # allow custom attributes and weak references (not used internally)
-    __slots__ = "__dict__", "__weakref__", "loc"
+    __slots__ = "__dict__", "__weakref__", "loc", "_hash"
 
     loc: Optional[Location]
 
@@ -255,7 +255,9 @@ class Node:
         )
 
     def __hash__(self) -> int:
-        return hash(tuple(getattr(self, key) for key in self.keys))
+        if getattr(self, "_hash", None) is None:
+            self._hash = hash(tuple(getattr(self, key) for key in self.keys))
+        return self._hash
 
     def __copy__(self) -> "Node":
         """Create a shallow copy of the node."""


### PR DESCRIPTION
This change adds basic caching for `Node.__hash__`. The primary goal of this change is to optimize validation. The benchmark I tested against is `tests/benchmarks/test_validation_gql.py`.

Locally, this benchmark goes from `7ms` to `4ms` with this change. I've also done some testing against an internal schema from our application, using a large query from our application instead of the introspection query. In that test, validation time dropped from `28ms` to `11ms` locally.