### PR TITLE
Fix evaluation for pseudo values

### DIFF
--- a/src/graphql/language/block_string.py
+++ b/src/graphql/language/block_string.py
@@ -99,7 +99,7 @@ def print_block_string(value: str, prefer_multiple_lines: bool = False) -> str:
         "\n"
         if print_as_multiple_lines and not (is_single_line and has_leading_space)
         else ""
-    ) + value
+    ) + str(value)
     if print_as_multiple_lines:
         result += "\n"
 

--- a/src/graphql/language/block_string.py
+++ b/src/graphql/language/block_string.py
@@ -83,6 +83,9 @@ def print_block_string(value: str, prefer_multiple_lines: bool = False) -> str:
 
     For internal use only.
     """
+    if not isinstance(value, str):
+        value = str(value)  # resolve lazy string proxy object
+
     is_single_line = "\n" not in value
     has_leading_space = value.startswith(" ") or value.startswith("\t")
     has_trailing_quote = value.endswith('"')
@@ -95,12 +98,12 @@ def print_block_string(value: str, prefer_multiple_lines: bool = False) -> str:
     )
 
     # Format a multi-line block quote to account for leading space.
-    result = (
+    before = (
         "\n"
         if print_as_multiple_lines and not (is_single_line and has_leading_space)
         else ""
-    ) + str(value)
-    if print_as_multiple_lines:
-        result += "\n"
+    )
+    after = "\n" if print_as_multiple_lines else ""
+    value = value.replace('"""', '\\"""')
 
-    return '"""' + result.replace('"""', '\\"""') + '"""'
+    return f'"""{before}{value}{after}"""'

--- a/tests/language/test_block_string.py
+++ b/tests/language/test_block_string.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from graphql.language.block_string import (
     dedent_block_string_value,
     print_block_string,
@@ -145,16 +147,9 @@ def describe_print_block_string():
             '"""', "    first  ", "  line     ", "indentation", "     string", '"""'
         )
 
-    def correctly_prints_value_if_proxy_object():
-        class PseudoProxyObject:
-            def __contains__(self, item):
-                return item in "lorem"
-
-            def __getattr__(self, item):
-                return getattr("lorem", item)
-
+    def correctly_prints_lazy_stings():
+        class LazyString:
             def __str__(self):
-                return "lorem"
+                return "lazy"
 
-        value = PseudoProxyObject()
-        assert print_block_string(value) == f'"""{value}"""'
+        assert print_block_string(cast(str, LazyString())) == '"""lazy"""'

--- a/tests/language/test_block_string.py
+++ b/tests/language/test_block_string.py
@@ -144,3 +144,17 @@ def describe_print_block_string():
         assert print_block_string(s) == join_lines(
             '"""', "    first  ", "  line     ", "indentation", "     string", '"""'
         )
+
+    def correctly_prints_value_if_proxy_object():
+        class PseudoProxyObject:
+            def __contains__(self, item):
+                return item in "lorem"
+
+            def __getattr__(self, item):
+                return getattr("lorem", item)
+
+            def __str__(self):
+                return "lorem"
+
+        value = PseudoProxyObject()
+        assert print_block_string(value) == f'"""{value}"""'


### PR DESCRIPTION
If the value is e. g. a lazy translation from Django's gettext_lazy,
the value should be stringified to be concatenated.