### PR TITLE
Make errors and extensions optional

### DIFF
--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -99,9 +99,9 @@ __all__ = [
 class FormattedExecutionResult(TypedDict, total=False):
     """Formatted execution result"""
 
-    errors: List[GraphQLFormattedError]
+    errors: Optional[List[GraphQLFormattedError]]
     data: Optional[Dict[str, Any]]
-    extensions: Dict[str, Any]
+    extensions: Optional[Dict[str, Any]]
 
 
 class ExecutionResult:

--- a/src/graphql/execution/execute.py
+++ b/src/graphql/execution/execute.py
@@ -99,8 +99,8 @@ __all__ = [
 class FormattedExecutionResult(TypedDict, total=False):
     """Formatted execution result"""
 
-    errors: Optional[List[GraphQLFormattedError]]
     data: Optional[Dict[str, Any]]
+    errors: Optional[List[GraphQLFormattedError]]
     extensions: Optional[Dict[str, Any]]
 
 


### PR DESCRIPTION
Just looking a bit on the codebase.
I think both errors and extensions should be optional.