### PR TITLE
Mention poetry instead of pipenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ GraphQL-core 3 can be installed from PyPI using the built-in pip command:
 
     python -m pip install graphql-core
 
-You can also use [pipenv](https://docs.pipenv.org/) for installation in a
+You can also use [poetry](https://github.com/python-poetry/poetry) for installation in a
 virtual environment:
 
-    pipenv install graphql-core
+    poetry install
 
 
 ## Usage

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -33,9 +33,9 @@ You can install GraphQL-core 3 using pip_::
 
     pip install graphql-core
 
-You can also install GraphQL-core 3 with pipenv_, if you prefer that::
+You can also install GraphQL-core 3 with poetry_, if you prefer that::
 
-    pipenv install graphql-core
+    poetry install
 
 Now you can start using GraphQL-core 3 by importing from the top-level
 :mod:`graphql` package. Nearly everything defined in the sub-packages
@@ -94,4 +94,4 @@ in the current development or want to report issues or send pull requests.
 .. _Execution: https://facebook.github.io/graphql/draft/#sec-Execution
 .. _Response: https://facebook.github.io/graphql/draft/#sec-Response
 .. _pip: https://pip.pypa.io/
-.. _pipenv: https://github.com/pypa/pipenv
+.. _poetry: https://github.com/python-poetry/poetry

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -50,8 +50,8 @@ def describe_introduction():
         intro = get_snippets("intro")
         pip_install = intro.pop(0)
         assert "pip install" in pip_install and "graphql-core" in pip_install
-        pipenv_install = intro.pop(0)
-        assert "pipenv install" in pipenv_install and "graphql-core" in pipenv_install
+        poetry_install = intro.pop(0)
+        assert "poetry install" in poetry_install
         create_schema = intro.pop(0)
         assert "schema = GraphQLSchema(" in create_schema
         scope: Scope = {}


### PR DESCRIPTION
Looking at the source tree, it appears that the `pipenv` system file does not exist and that it is assumed to use `poetry` instead.
Therefore, I change the description to use poetry.
