### PR TITLE
Represent serialized floats to python float precision

### DIFF
--- a/src/graphql/utilities/ast_from_value.py
+++ b/src/graphql/utilities/ast_from_value.py
@@ -117,7 +117,7 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
         if isinstance(serialized, int):
             return IntValueNode(value=f"{serialized:d}")
         if isinstance(serialized, float) and isfinite(serialized):
-            return FloatValueNode(value=f"{serialized:g}")
+            return FloatValueNode(value=f"{serialized:.16g}")
 
         if isinstance(serialized, str):
             # Enum types use Enum literals.

--- a/src/graphql/utilities/ast_from_value.py
+++ b/src/graphql/utilities/ast_from_value.py
@@ -117,7 +117,10 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
         if isinstance(serialized, int):
             return IntValueNode(value=f"{serialized:d}")
         if isinstance(serialized, float) and isfinite(serialized):
-            return FloatValueNode(value=f"{serialized:.16g}")
+            value = str(serialized)
+            if value.endswith('.0'):
+                value = value[:-2]
+            return FloatValueNode(value=value)
 
         if isinstance(serialized, str):
             # Enum types use Enum literals.

--- a/src/graphql/utilities/ast_from_value.py
+++ b/src/graphql/utilities/ast_from_value.py
@@ -115,7 +115,7 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
 
         # Python ints and floats correspond nicely to Int and Float values.
         if isinstance(serialized, int):
-            return IntValueNode(value=f"{serialized:d}")
+            return IntValueNode(value=str(serialized))
         if isinstance(serialized, float) and isfinite(serialized):
             value = str(serialized)
             if value.endswith('.0'):

--- a/tests/utilities/test_ast_from_value.py
+++ b/tests/utilities/test_ast_from_value.py
@@ -86,6 +86,10 @@ def describe_ast_from_value():
 
         assert ast_from_value(1e40, GraphQLFloat) == FloatValueNode(value="1e+40")
 
+        assert ast_from_value(123456789.0123456, GraphQLFloat) == FloatValueNode(
+            value="123456789.0123456"
+        )
+
     def converts_string_values_to_string_asts():
         assert ast_from_value("hello", GraphQLString) == StringValueNode(value="hello")
 

--- a/tests/utilities/test_ast_from_value.py
+++ b/tests/utilities/test_ast_from_value.py
@@ -90,8 +90,6 @@ def describe_ast_from_value():
             value="123456789.01234567"
         )
 
-        assert ast_from_value(1.0, GraphQLFloat) == FloatValueNode(value="1")
-
         assert ast_from_value(1.1, GraphQLFloat) == FloatValueNode(value="1.1")
 
     def converts_string_values_to_string_asts():

--- a/tests/utilities/test_ast_from_value.py
+++ b/tests/utilities/test_ast_from_value.py
@@ -86,9 +86,13 @@ def describe_ast_from_value():
 
         assert ast_from_value(1e40, GraphQLFloat) == FloatValueNode(value="1e+40")
 
-        assert ast_from_value(123456789.0123456, GraphQLFloat) == FloatValueNode(
-            value="123456789.0123456"
+        assert ast_from_value(123456789.01234567, GraphQLFloat) == FloatValueNode(
+            value="123456789.01234567"
         )
+
+        assert ast_from_value(1.0, GraphQLFloat) == FloatValueNode(value="1")
+
+        assert ast_from_value(1.1, GraphQLFloat) == FloatValueNode(value="1.1")
 
     def converts_string_values_to_string_asts():
         assert ast_from_value("hello", GraphQLString) == StringValueNode(value="hello")


### PR DESCRIPTION
Currently, the general string format used in the serialisation of a float value uses the default precision of 6, which leads to a loss in precision of large/long numbers. This PR changes the precision to use up to 16 places, which is approximately the level of precision of a float. This doesn't have any impact on the existing tests that don't have numbers with precision > 6, and the added assertion in the existing test fails without the change.