### PR TITLE
[WIP] Proposal: replace asyncio with anyio

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,12 +7,32 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-category = "dev"
+name = "anyio"
+version = "3.5.0"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+contextvars = {version = "*", markers = "python_version < \"3.7\""}
+dataclasses = {version = "*", markers = "python_version < \"3.7\""}
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+trio = ["trio (>=0.16)"]
+
+[[package]]
+name = "async-generator"
+version = "1.10"
+description = "Async generators and context managers for Python 3.5+"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "atomicwrites"
@@ -26,7 +46,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 name = "attrs"
 version = "21.4.0"
 description = "Classes Without Boilerplate"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -46,29 +66,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
 pytz = ">=2015.7"
-
-[[package]]
-name = "black"
-version = "20.8b1"
-description = "The uncompromising code formatter."
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-appdirs = "*"
-click = ">=7.1.2"
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
-mypy-extensions = ">=0.4.3"
-pathspec = ">=0.6,<1"
-regex = ">=2020.1.8"
-toml = ">=0.10.1"
-typed-ast = ">=1.4.0"
-typing-extensions = ">=3.7.4"
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "black"
@@ -132,6 +129,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "cffi"
+version = "1.15.0"
+description = "Foreign Function Interface for Python calling C code."
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+pycparser = "*"
+
+[[package]]
 name = "charset-normalizer"
 version = "2.0.11"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
@@ -178,6 +186,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "contextvars"
+version = "2.4"
+description = "PEP 567 Backport"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+immutables = ">=0.9"
+
+[[package]]
 name = "coverage"
 version = "6.2"
 description = "Code coverage measurement for Python"
@@ -195,7 +214,7 @@ toml = ["tomli"]
 name = "dataclasses"
 version = "0.8"
 description = "A backport of the dataclasses module for Python 3.6"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6, <3.7"
 
@@ -245,7 +264,7 @@ pyflakes = ">=2.4.0,<2.5.0"
 name = "idna"
 version = "3.3"
 description = "Internationalized Domain Names in Applications (IDNA)"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.5"
 
@@ -256,6 +275,20 @@ description = "Getting image size from png/jpeg/jpeg2000/gif file"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "immutables"
+version = "0.17"
+description = "Immutable Collections"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
+
+[package.extras]
+test = ["flake8 (>=3.8.4,<3.9.0)", "pycodestyle (>=2.6.0,<2.7.0)", "mypy (>=0.910)", "pytest (>=6.2.4,<6.3.0)"]
 
 [[package]]
 name = "importlib-metadata"
@@ -353,6 +386,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "outcome"
+version = "1.1.0"
+description = "Capture the outcome of Python function calls."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+
+[[package]]
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
@@ -436,6 +480,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "pycparser"
+version = "2.21"
+description = "C parser in Python"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
 name = "pyflakes"
 version = "2.4.0"
 description = "passive checker of Python programs"
@@ -483,35 +535,6 @@ toml = "*"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
-
-[[package]]
-name = "pytest-asyncio"
-version = "0.16.0"
-description = "Pytest support for asyncio."
-category = "dev"
-optional = false
-python-versions = ">= 3.6"
-
-[package.dependencies]
-pytest = ">=5.4.0"
-
-[package.extras]
-testing = ["coverage", "hypothesis (>=5.7.1)"]
-
-[[package]]
-name = "pytest-asyncio"
-version = "0.17.2"
-description = "Pytest support for asyncio"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-pytest = ">=6.1.0"
-typing-extensions = {version = ">=4.0", markers = "python_version < \"3.8\""}
-
-[package.extras]
-testing = ["coverage (==6.2)", "hypothesis (>=5.7.1)", "flaky (>=3.5.0)", "mypy (==0.931)"]
 
 [[package]]
 name = "pytest-benchmark"
@@ -576,14 +599,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "regex"
-version = "2022.1.18"
-description = "Alternative regular expression module, to replace re."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "requests"
 version = "2.27.1"
 description = "Python HTTP for Humans."
@@ -610,10 +625,29 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "sniffio"
+version = "1.2.0"
+description = "Sniff out which async library your code is running under"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+contextvars = {version = ">=2.1", markers = "python_version < \"3.7\""}
+
+[[package]]
 name = "snowballstemmer"
 version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+category = "main"
 optional = false
 python-versions = "*"
 
@@ -774,6 +808,39 @@ docs = ["pygments-github-lexers (>=0.0.5)", "sphinx (>=2.0.0)", "sphinxcontrib-a
 testing = ["flaky (>=3.4.0)", "freezegun (>=0.3.11)", "pytest (>=4.0.0)", "pytest-cov (>=2.5.1)", "pytest-mock (>=1.10.0)", "pytest-randomly (>=1.0.0)", "psutil (>=5.6.1)", "pathlib2 (>=2.3.3)"]
 
 [[package]]
+name = "trio"
+version = "0.20.0"
+description = "A friendly Python library for async concurrency and I/O"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+async-generator = ">=1.9"
+attrs = ">=19.2.0"
+cffi = {version = ">=1.14", markers = "os_name == \"nt\" and implementation_name != \"pypy\""}
+idna = "*"
+outcome = "*"
+sniffio = "*"
+sortedcontainers = "*"
+
+[[package]]
+name = "trio-typing"
+version = "0.7.0"
+description = "Static type checking support for Trio and related projects"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.2"
+trio = ">=0.16.0"
+typing-extensions = ">=3.7.4"
+
+[package.extras]
+mypy = ["mypy (>=0.920)"]
+
+[[package]]
 name = "typed-ast"
 version = "1.5.2"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
@@ -834,19 +901,26 @@ python-versions = ">=3.6"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
+[extras]
+trio = ["trio"]
+
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6"
-content-hash = "0021159270f76a4837a7240f8c34959323722ff896baf7bfccdf5cf08034f544"
+python-versions = "^3.6,>=3.6.2"
+content-hash = "cafb9065d6eb88e9584296e6e24631f986c6c773c13700826c9665a66aa2278a"
 
 [metadata.files]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
-appdirs = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+anyio = [
+    {file = "anyio-3.5.0-py3-none-any.whl", hash = "sha256:b5fa16c5ff93fa1046f2eeb5bbff2dad4d3514d6cda61d02816dba34fa8c3c2e"},
+    {file = "anyio-3.5.0.tar.gz", hash = "sha256:a0aeffe2fb1fdf374a8e4b471444f0f3ac4fb9f5a5b542b48824475e0042a5a6"},
+]
+async-generator = [
+    {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
+    {file = "async_generator-1.10.tar.gz", hash = "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -861,7 +935,6 @@ babel = [
     {file = "Babel-2.9.1.tar.gz", hash = "sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0"},
 ]
 black = [
-    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
     {file = "black-22.1.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:1297c63b9e1b96a3d0da2d85d11cd9bf8664251fd69ddac068b98dc4f34f73b6"},
     {file = "black-22.1.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2ff96450d3ad9ea499fc4c60e425a1439c2120cbbc1ab959ff20f7c76ec7e866"},
     {file = "black-22.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e21e1f1efa65a50e3960edd068b6ae6d64ad6235bd8bfea116a03b21836af71"},
@@ -898,6 +971,58 @@ certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
     {file = "certifi-2021.10.8.tar.gz", hash = "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872"},
 ]
+cffi = [
+    {file = "cffi-1.15.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962"},
+    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0"},
+    {file = "cffi-1.15.0-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14"},
+    {file = "cffi-1.15.0-cp27-cp27m-win32.whl", hash = "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474"},
+    {file = "cffi-1.15.0-cp27-cp27m-win_amd64.whl", hash = "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6"},
+    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27"},
+    {file = "cffi-1.15.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023"},
+    {file = "cffi-1.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2"},
+    {file = "cffi-1.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962"},
+    {file = "cffi-1.15.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382"},
+    {file = "cffi-1.15.0-cp310-cp310-win32.whl", hash = "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55"},
+    {file = "cffi-1.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0"},
+    {file = "cffi-1.15.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8"},
+    {file = "cffi-1.15.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605"},
+    {file = "cffi-1.15.0-cp36-cp36m-win32.whl", hash = "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e"},
+    {file = "cffi-1.15.0-cp36-cp36m-win_amd64.whl", hash = "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc"},
+    {file = "cffi-1.15.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2"},
+    {file = "cffi-1.15.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7"},
+    {file = "cffi-1.15.0-cp37-cp37m-win32.whl", hash = "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66"},
+    {file = "cffi-1.15.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029"},
+    {file = "cffi-1.15.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728"},
+    {file = "cffi-1.15.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6"},
+    {file = "cffi-1.15.0-cp38-cp38-win32.whl", hash = "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c"},
+    {file = "cffi-1.15.0-cp38-cp38-win_amd64.whl", hash = "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443"},
+    {file = "cffi-1.15.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a"},
+    {file = "cffi-1.15.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df"},
+    {file = "cffi-1.15.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8"},
+    {file = "cffi-1.15.0-cp39-cp39-win32.whl", hash = "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a"},
+    {file = "cffi-1.15.0-cp39-cp39-win_amd64.whl", hash = "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139"},
+    {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
+]
 charset-normalizer = [
     {file = "charset-normalizer-2.0.11.tar.gz", hash = "sha256:98398a9d69ee80548c762ba991a4728bfc3836768ed226b3945908d1a688371c"},
     {file = "charset_normalizer-2.0.11-py3-none-any.whl", hash = "sha256:2842d8f5e82a1f6aa437380934d5e1cd4fcf2003b06fed6940769c164a480a45"},
@@ -913,6 +1038,9 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+contextvars = [
+    {file = "contextvars-2.4.tar.gz", hash = "sha256:f38c908aaa59c14335eeea12abea5f443646216c4e29380d7bf34d2018e2c39e"},
 ]
 coverage = [
     {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
@@ -990,6 +1118,57 @@ idna = [
 imagesize = [
     {file = "imagesize-1.3.0-py2.py3-none-any.whl", hash = "sha256:1db2f82529e53c3e929e8926a1fa9235aa82d0bd0c580359c67ec31b2fddaa8c"},
     {file = "imagesize-1.3.0.tar.gz", hash = "sha256:cd1750d452385ca327479d45b64d9c7729ecf0b3969a58148298c77092261f9d"},
+]
+immutables = [
+    {file = "immutables-0.17-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cab10d65a29b2019fffd7a3924f6965a8f785e7bd409641ce36ab2d3335f88c4"},
+    {file = "immutables-0.17-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f73088c9b8595ddfd45a5658f8cce0cb3ae6e5890458381fccba3ed3035081d4"},
+    {file = "immutables-0.17-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ef632832fa1acae6861d83572b866126f9e35706ab6e581ce6b175b3e0b7a3c4"},
+    {file = "immutables-0.17-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0efdcec7b63859b41f794ffa0cd0d6dc87e77d1be4ff0ec23471a3a1e719235f"},
+    {file = "immutables-0.17-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3eca96f12bc1535657d24eae2c69816d0b22c4a4bc7f4753115e028a137e8dad"},
+    {file = "immutables-0.17-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:01a25b1056754aa486afea5471ca348410d77f458477ccb6fa3baf2d3e3ff3d5"},
+    {file = "immutables-0.17-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:c41a6648f7355f1241da677c418edae56fdc45af19ad3540ca8a1e7a81606a7a"},
+    {file = "immutables-0.17-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0b578bba11bd8ae55dee9536edf8d82be18463d15d4b4c9827e27eeeb73826bf"},
+    {file = "immutables-0.17-cp310-cp310-win32.whl", hash = "sha256:a28682e115191e909673aedb9ccea3377da3a6a929f8bd86982a2a76bdfa89db"},
+    {file = "immutables-0.17-cp310-cp310-win_amd64.whl", hash = "sha256:293ddb681502945f29b3065e688a962e191e752320040892316b9dd1e3b9c8c9"},
+    {file = "immutables-0.17-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ec04fc7d9f76f26d82a5d9d1715df0409d0096309828fc46cd1a2067c7fbab95"},
+    {file = "immutables-0.17-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f024f25e9fda42251a2b2167668ca70678c19fb3ab6ed509cef0b4b431d0ff73"},
+    {file = "immutables-0.17-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b02083b2052cc201ac5cbd38f34a5da21fcd51016cb4ddd1fb43d7dc113eac17"},
+    {file = "immutables-0.17-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea32db31afb82d8369e98f85c5b815ff81610a12fbc837830a34388f1b56f080"},
+    {file = "immutables-0.17-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:898a9472d1dd3d17f291114395a1be65be035355fc65af0b2c88238f8fbeaa62"},
+    {file = "immutables-0.17-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:736dd3d88d44da0ee48804792bd095c01a344c5d1b0f10beeb9ccb3a00b9c19d"},
+    {file = "immutables-0.17-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:15ff4139720f79b902f435a25e3c00f9c8adcc41d79bed64b7e51ae36cfe9620"},
+    {file = "immutables-0.17-cp36-cp36m-win32.whl", hash = "sha256:4f018a6c4c3689b82f763ad4f84dec6aa91c83981db7f6bafef963f036e5e815"},
+    {file = "immutables-0.17-cp36-cp36m-win_amd64.whl", hash = "sha256:d7400a6753b292ac80102ed026efa8da2c3fedd50c443924cbe9b6448d3b19e4"},
+    {file = "immutables-0.17-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f7a6e0380bddb99c46bb3f12ae5eee9a23d6a66d99bbf0fb10fa552f935c2e8d"},
+    {file = "immutables-0.17-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7696c42d1f9a16ecda0ee46229848df8706973690b45e8a090d995d647a5ec57"},
+    {file = "immutables-0.17-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:892b6a1619cd8c398fa70302c4cfa9768a694377639330e7a58cc7be111ab23e"},
+    {file = "immutables-0.17-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:89093d5a85357250b1d5ae218fdcfdbac4097cbb2d8b55004aa7a2ca2a00a09f"},
+    {file = "immutables-0.17-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:99a8bc6d0623300eb46beea74f7a5061968fb3efc4e072f23f6c0b21c588238d"},
+    {file = "immutables-0.17-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:00380474f8e3b4a2eeb06ce694e0e3cb85a144919140a2b3116defb6c1587471"},
+    {file = "immutables-0.17-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:078e3ed63be0ac36523b80bbabbfb1bb57e55009f4efb5650b0e3b3ed569c3f1"},
+    {file = "immutables-0.17-cp37-cp37m-win32.whl", hash = "sha256:14905aecc62b318d86045dcf8d35ef2063803d9d331aeccd88958f03caadc7b0"},
+    {file = "immutables-0.17-cp37-cp37m-win_amd64.whl", hash = "sha256:3774d403d1570105a1da2e00c38ce3f04065fd1deff04cf998f8d8e946d0ae13"},
+    {file = "immutables-0.17-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e5a9caee1b99eccf1447056ae6bda77edd15c357421293e81fa1a4f28e83448a"},
+    {file = "immutables-0.17-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:fed1e1baf1de1bc94a0310da29814892064928d7d40ff5a3b86bcd11d5e7cfff"},
+    {file = "immutables-0.17-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d7daa340d76747ba5a8f64816b48def74bd4be45a9508073b34fa954d099fba"},
+    {file = "immutables-0.17-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4644c29fe07fb92ba84b26659708e1799fecaaf781214adf13edd8a4d7495a9"},
+    {file = "immutables-0.17-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1e9ea0e2a31db44fb01617ff875d4c26f962696e1c5ff11ed7767c2d8dedac4"},
+    {file = "immutables-0.17-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:64100dfdb29fae2bc84748fff5d66dd6b3997806c717eeb75f7099aeee9b1878"},
+    {file = "immutables-0.17-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5f933e5bf6f2c1afb24bc2fc8bea8b132096a4a6ba54f36be59787981f3e50ff"},
+    {file = "immutables-0.17-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:9508a087a47f9f9506adf2fa8383ab14c46a222b57eea8612bc4c2aa9a9550fe"},
+    {file = "immutables-0.17-cp38-cp38-win32.whl", hash = "sha256:dfd2c63f15d1e5ea1ed2a05b7c602b5f61a64337415d299df20e103a57ae4906"},
+    {file = "immutables-0.17-cp38-cp38-win_amd64.whl", hash = "sha256:301c539660c988c5b24051ccad1e36c040a916f1e58fa3e245e3122fc50dd28d"},
+    {file = "immutables-0.17-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:563bc2ddbe75c10faa3b4b0206870653b44a231b97ed23cff8ab8aff503d922d"},
+    {file = "immutables-0.17-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f621ea6130393cd14d0fbd35b306d4dc70bcd0fda550a8cd313db8015e34ca60"},
+    {file = "immutables-0.17-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57c2d1b16b716bca70345db334dd6a861bf45c46cb11bb1801277f8a9012e864"},
+    {file = "immutables-0.17-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a08e1a80bd8c5df72c2bf0af24a37ceec17e8ffdb850ed5a62d0bba1d4d86018"},
+    {file = "immutables-0.17-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6b99155ad112149d43208c611c6c42f19e16716526dacc0fcc16736d2f5d2e20"},
+    {file = "immutables-0.17-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ed71e736f8fb82545d00c8969dbc167547c15e85729058edbed3c03b94fca86c"},
+    {file = "immutables-0.17-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:19e4b8e5810dd7cab63fa700373f787a369d992166eabc23f4b962e5704d33c5"},
+    {file = "immutables-0.17-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:305062012497d4c4a70fe35e20cef2c6f65744e721b04671092a63354799988d"},
+    {file = "immutables-0.17-cp39-cp39-win32.whl", hash = "sha256:f5c6bd012384a8d6af7bb25675719214d76640fe6c336e2b5fba9eef1407ae6a"},
+    {file = "immutables-0.17-cp39-cp39-win_amd64.whl", hash = "sha256:615ab26873a794559ccaf4e0e9afdb5aefad0867c15262ba64a55a12a5a41573"},
+    {file = "immutables-0.17.tar.gz", hash = "sha256:ad894446355b6f5289a9c84fb46f7c47c6ef2b1bfbdd2be6cb177dbb7f1587ad"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.2.0-py3-none-any.whl", hash = "sha256:057e92c15bc8d9e8109738a48db0ccb31b4d9d5cfbee5a8670879a30be66304b"},
@@ -1073,6 +1252,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+outcome = [
+    {file = "outcome-1.1.0-py2.py3-none-any.whl", hash = "sha256:c7dd9375cfd3c12db9801d080a3b63d4b0a261aa996c4c13152380587288d958"},
+    {file = "outcome-1.1.0.tar.gz", hash = "sha256:e862f01d4e626e63e8f92c38d1f8d5546d3f9cce989263c521b2e7990d186967"},
+]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -1104,6 +1287,10 @@ pycodestyle = [
     {file = "pycodestyle-2.8.0-py2.py3-none-any.whl", hash = "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20"},
     {file = "pycodestyle-2.8.0.tar.gz", hash = "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"},
 ]
+pycparser = [
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
+]
 pyflakes = [
     {file = "pyflakes-2.4.0-py2.py3-none-any.whl", hash = "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"},
     {file = "pyflakes-2.4.0.tar.gz", hash = "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c"},
@@ -1119,12 +1306,6 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
-]
-pytest-asyncio = [
-    {file = "pytest-asyncio-0.16.0.tar.gz", hash = "sha256:7496c5977ce88c34379df64a66459fe395cd05543f0a2f837016e7144391fcfb"},
-    {file = "pytest_asyncio-0.16.0-py3-none-any.whl", hash = "sha256:5f2a21273c47b331ae6aa5b36087047b4899e40f03f18397c0e65fa5cca54e9b"},
-    {file = "pytest-asyncio-0.17.2.tar.gz", hash = "sha256:6d895b02432c028e6957d25fc936494e78c6305736e785d9fee408b1efbc7ff4"},
-    {file = "pytest_asyncio-0.17.2-py3-none-any.whl", hash = "sha256:e0fe5dbea40516b661ef1bcfe0bd9461c2847c4ef4bb40012324f2454fb7d56d"},
 ]
 pytest-benchmark = [
     {file = "pytest-benchmark-3.4.1.tar.gz", hash = "sha256:40e263f912de5a81d891619032983557d62a3d85843f9a9f30b98baea0cd7b47"},
@@ -1146,82 +1327,6 @@ pytz = [
     {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
     {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
-regex = [
-    {file = "regex-2022.1.18-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:34316bf693b1d2d29c087ee7e4bb10cdfa39da5f9c50fa15b07489b4ab93a1b5"},
-    {file = "regex-2022.1.18-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a0b9f6a1a15d494b35f25ed07abda03209fa76c33564c09c9e81d34f4b919d7"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f99112aed4fb7cee00c7f77e8b964a9b10f69488cdff626ffd797d02e2e4484f"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a2bf98ac92f58777c0fafc772bf0493e67fcf677302e0c0a630ee517a43b949"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8618d9213a863c468a865e9d2ec50221015f7abf52221bc927152ef26c484b4c"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b52cc45e71657bc4743a5606d9023459de929b2a198d545868e11898ba1c3f59"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7e12949e5071c20ec49ef00c75121ed2b076972132fc1913ddf5f76cae8d10b4"},
-    {file = "regex-2022.1.18-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:b02e3e72665cd02afafb933453b0c9f6c59ff6e3708bd28d0d8580450e7e88af"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:abfcb0ef78df0ee9df4ea81f03beea41849340ce33a4c4bd4dbb99e23ec781b6"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6213713ac743b190ecbf3f316d6e41d099e774812d470422b3a0f137ea635832"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:61ebbcd208d78658b09e19c78920f1ad38936a0aa0f9c459c46c197d11c580a0"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:b013f759cd69cb0a62de954d6d2096d648bc210034b79b1881406b07ed0a83f9"},
-    {file = "regex-2022.1.18-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9187500d83fd0cef4669385cbb0961e227a41c0c9bc39219044e35810793edf7"},
-    {file = "regex-2022.1.18-cp310-cp310-win32.whl", hash = "sha256:94c623c331a48a5ccc7d25271399aff29729fa202c737ae3b4b28b89d2b0976d"},
-    {file = "regex-2022.1.18-cp310-cp310-win_amd64.whl", hash = "sha256:1a171eaac36a08964d023eeff740b18a415f79aeb212169080c170ec42dd5184"},
-    {file = "regex-2022.1.18-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:49810f907dfe6de8da5da7d2b238d343e6add62f01a15d03e2195afc180059ed"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d2f5c3f7057530afd7b739ed42eb04f1011203bc5e4663e1e1d01bb50f813e3"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:85ffd6b1cb0dfb037ede50ff3bef80d9bf7fa60515d192403af6745524524f3b"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ba37f11e1d020969e8a779c06b4af866ffb6b854d7229db63c5fdddfceaa917f"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e27ea1ebe4a561db75a880ac659ff439dec7f55588212e71700bb1ddd5af9"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:37978254d9d00cda01acc1997513f786b6b971e57b778fbe7c20e30ae81a97f3"},
-    {file = "regex-2022.1.18-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:e54a1eb9fd38f2779e973d2f8958fd575b532fe26013405d1afb9ee2374e7ab8"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:768632fd8172ae03852e3245f11c8a425d95f65ff444ce46b3e673ae5b057b74"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:de2923886b5d3214be951bc2ce3f6b8ac0d6dfd4a0d0e2a4d2e5523d8046fdfb"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_ppc64le.whl", hash = "sha256:1333b3ce73269f986b1fa4d5d395643810074dc2de5b9d262eb258daf37dc98f"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_s390x.whl", hash = "sha256:d19a34f8a3429bd536996ad53597b805c10352a8561d8382e05830df389d2b43"},
-    {file = "regex-2022.1.18-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d2f355a951f60f0843f2368b39970e4667517e54e86b1508e76f92b44811a8a"},
-    {file = "regex-2022.1.18-cp36-cp36m-win32.whl", hash = "sha256:2245441445099411b528379dee83e56eadf449db924648e5feb9b747473f42e3"},
-    {file = "regex-2022.1.18-cp36-cp36m-win_amd64.whl", hash = "sha256:25716aa70a0d153cd844fe861d4f3315a6ccafce22b39d8aadbf7fcadff2b633"},
-    {file = "regex-2022.1.18-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7e070d3aef50ac3856f2ef5ec7214798453da878bb5e5a16c16a61edf1817cc3"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22709d701e7037e64dae2a04855021b62efd64a66c3ceed99dfd684bfef09e38"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9099bf89078675c372339011ccfc9ec310310bf6c292b413c013eb90ffdcafc"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04611cc0f627fc4a50bc4a9a2e6178a974c6a6a4aa9c1cca921635d2c47b9c87"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:552a39987ac6655dad4bf6f17dd2b55c7b0c6e949d933b8846d2e312ee80005a"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1e031899cb2bc92c0cf4d45389eff5b078d1936860a1be3aa8c94fa25fb46ed8"},
-    {file = "regex-2022.1.18-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2dacb3dae6b8cc579637a7b72f008bff50a94cde5e36e432352f4ca57b9e54c4"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:e5c31d70a478b0ca22a9d2d76d520ae996214019d39ed7dd93af872c7f301e52"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:bb804c7d0bfbd7e3f33924ff49757de9106c44e27979e2492819c16972ec0da2"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_ppc64le.whl", hash = "sha256:36b2d700a27e168fa96272b42d28c7ac3ff72030c67b32f37c05616ebd22a202"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_s390x.whl", hash = "sha256:16f81025bb3556eccb0681d7946e2b35ff254f9f888cff7d2120e8826330315c"},
-    {file = "regex-2022.1.18-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:da80047524eac2acf7c04c18ac7a7da05a9136241f642dd2ed94269ef0d0a45a"},
-    {file = "regex-2022.1.18-cp37-cp37m-win32.whl", hash = "sha256:6ca45359d7a21644793de0e29de497ef7f1ae7268e346c4faf87b421fea364e6"},
-    {file = "regex-2022.1.18-cp37-cp37m-win_amd64.whl", hash = "sha256:38289f1690a7e27aacd049e420769b996826f3728756859420eeee21cc857118"},
-    {file = "regex-2022.1.18-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6014038f52b4b2ac1fa41a58d439a8a00f015b5c0735a0cd4b09afe344c94899"},
-    {file = "regex-2022.1.18-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0b5d6f9aed3153487252d00a18e53f19b7f52a1651bc1d0c4b5844bc286dfa52"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9d24b03daf7415f78abc2d25a208f234e2c585e5e6f92f0204d2ab7b9ab48e3"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bf594cc7cc9d528338d66674c10a5b25e3cde7dd75c3e96784df8f371d77a298"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fd914db437ec25bfa410f8aa0aa2f3ba87cdfc04d9919d608d02330947afaeab"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90b6840b6448203228a9d8464a7a0d99aa8fa9f027ef95fe230579abaf8a6ee1"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11772be1eb1748e0e197a40ffb82fb8fd0d6914cd147d841d9703e2bef24d288"},
-    {file = "regex-2022.1.18-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a602bdc8607c99eb5b391592d58c92618dcd1537fdd87df1813f03fed49957a6"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:7e26eac9e52e8ce86f915fd33380f1b6896a2b51994e40bb094841e5003429b4"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:519c0b3a6fbb68afaa0febf0d28f6c4b0a1074aefc484802ecb9709faf181607"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_ppc64le.whl", hash = "sha256:3c7ea86b9ca83e30fa4d4cd0eaf01db3ebcc7b2726a25990966627e39577d729"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_s390x.whl", hash = "sha256:51f02ca184518702975b56affde6c573ebad4e411599005ce4468b1014b4786c"},
-    {file = "regex-2022.1.18-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:385ccf6d011b97768a640e9d4de25412204fbe8d6b9ae39ff115d4ff03f6fe5d"},
-    {file = "regex-2022.1.18-cp38-cp38-win32.whl", hash = "sha256:1f8c0ae0a0de4e19fddaaff036f508db175f6f03db318c80bbc239a1def62d02"},
-    {file = "regex-2022.1.18-cp38-cp38-win_amd64.whl", hash = "sha256:760c54ad1b8a9b81951030a7e8e7c3ec0964c1cb9fee585a03ff53d9e531bb8e"},
-    {file = "regex-2022.1.18-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:93c20777a72cae8620203ac11c4010365706062aa13aaedd1a21bb07adbb9d5d"},
-    {file = "regex-2022.1.18-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:6aa427c55a0abec450bca10b64446331b5ca8f79b648531138f357569705bc4a"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c38baee6bdb7fe1b110b6b3aaa555e6e872d322206b7245aa39572d3fc991ee4"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:752e7ddfb743344d447367baa85bccd3629c2c3940f70506eb5f01abce98ee68"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8acef4d8a4353f6678fd1035422a937c2170de58a2b29f7da045d5249e934101"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c73d2166e4b210b73d1429c4f1ca97cea9cc090e5302df2a7a0a96ce55373f1c"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:24c89346734a4e4d60ecf9b27cac4c1fee3431a413f7aa00be7c4d7bbacc2c4d"},
-    {file = "regex-2022.1.18-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:596f5ae2eeddb79b595583c2e0285312b2783b0ec759930c272dbf02f851ff75"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:ecfe51abf7f045e0b9cdde71ca9e153d11238679ef7b5da6c82093874adf3338"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:1d6301f5288e9bdca65fab3de6b7de17362c5016d6bf8ee4ba4cbe833b2eda0f"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_ppc64le.whl", hash = "sha256:93cce7d422a0093cfb3606beae38a8e47a25232eea0f292c878af580a9dc7605"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_s390x.whl", hash = "sha256:cf0db26a1f76aa6b3aa314a74b8facd586b7a5457d05b64f8082a62c9c49582a"},
-    {file = "regex-2022.1.18-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:defa0652696ff0ba48c8aff5a1fac1eef1ca6ac9c660b047fc8e7623c4eb5093"},
-    {file = "regex-2022.1.18-cp39-cp39-win32.whl", hash = "sha256:6db1b52c6f2c04fafc8da17ea506608e6be7086715dab498570c3e55e4f8fbd1"},
-    {file = "regex-2022.1.18-cp39-cp39-win_amd64.whl", hash = "sha256:ebaeb93f90c0903233b11ce913a7cb8f6ee069158406e056f884854c737d2442"},
-    {file = "regex-2022.1.18.tar.gz", hash = "sha256:97f32dc03a8054a4c4a5ab5d761ed4861e828b2c200febd4e46857069a483916"},
-]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},
     {file = "requests-2.27.1.tar.gz", hash = "sha256:68d7c56fd5a8999887728ef304a6d12edc7be74f1cfa47714fc8b414525c9a61"},
@@ -1230,9 +1335,17 @@ six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
+sniffio = [
+    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
+    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
+]
+sortedcontainers = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 sphinx = [
     {file = "Sphinx-4.3.2-py3-none-any.whl", hash = "sha256:6a11ea5dd0bdb197f9c2abc2e0ce73e01340464feaece525e64036546d24c851"},
@@ -1277,6 +1390,14 @@ tomli = [
 tox = [
     {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
     {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
+]
+trio = [
+    {file = "trio-0.20.0-py3-none-any.whl", hash = "sha256:fb2d48e4eab0dfb786a472cd514aaadc71e3445b203bc300bad93daa75d77c1a"},
+    {file = "trio-0.20.0.tar.gz", hash = "sha256:670a52d3115d0e879e1ac838a4eb999af32f858163e3a704fe4839de2a676070"},
+]
+trio-typing = [
+    {file = "trio-typing-0.7.0.tar.gz", hash = "sha256:5bb2184de144c15f2cc252bba4fd167125758df7339c4f7bc40538940aefa3b9"},
+    {file = "trio_typing-0.7.0-py3-none-any.whl", hash = "sha256:156ba760f444aa2f8af43f4459d462415fc297234feb27018e4e902bb62a122b"},
 ]
 typed-ast = [
     {file = "typed_ast-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,15 +42,12 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = "^3.6,>=3.6.2"
 typing-extensions = { version = "^4.0", python = "<3.8" }
+anyio = "^3.5.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"
-pytest-asyncio = [
-    {version=">=0.17,<1", python = ">=3.7" },
-    {version=">=0.16,<0.17", python = "<3.7" },
-]
 pytest-benchmark = "^3.4"
 pytest-cov = "^3.0"
 pytest-describe = "^2.0"
@@ -66,6 +63,7 @@ sphinx_rtd_theme = ">=1,<2"
 check-manifest = ">=0.47,<1"
 bump2version = ">=1.0,<2"
 tox = "^3.24"
+trio = { version = "^0.20.0", python = ">=3.7"}
 
 [tool.black]
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ packages = [
 python = "^3.6,>=3.6.2"
 typing-extensions = { version = "^4.0", python = "<3.8" }
 anyio = "^3.5.0"
+trio = { version = "^0.20.0", python = ">=3.7", optional=true}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"
@@ -63,7 +64,11 @@ sphinx_rtd_theme = ">=1,<2"
 check-manifest = ">=0.47,<1"
 bump2version = ">=1.0,<2"
 tox = "^3.24"
-trio = { version = "^0.20.0", python = ">=3.7"}
+trio-typing = "^0.7.0"
+
+[tool.poetry.extras]
+trio = ["trio"]
+
 
 [tool.black]
 target-version = ['py36', 'py37', 'py38', 'py39', 'py310']

--- a/src/graphql/execution/subscribe.py
+++ b/src/graphql/execution/subscribe.py
@@ -1,3 +1,4 @@
+from asyncio import CancelledError
 from inspect import isawaitable
 from typing import (
     Any,
@@ -209,4 +210,6 @@ async def execute_subscription(context: ExecutionContext) -> AsyncIterable[Any]:
 
         return event_stream
     except Exception as error:
+        if isinstance(error, CancelledError):  # pragma: no cover (Python >= 3.8)
+            raise
         raise located_error(error, field_nodes, path.as_list())

--- a/src/graphql/graphql.py
+++ b/src/graphql/graphql.py
@@ -1,4 +1,5 @@
 from asyncio import ensure_future
+from sniffio import current_async_library
 from inspect import isawaitable
 from typing import Any, Awaitable, Callable, Dict, Optional, Union, Type, cast
 
@@ -143,7 +144,8 @@ def graphql_sync(
 
     # Assert that the execution was synchronous.
     if isawaitable(result):
-        ensure_future(cast(Awaitable[ExecutionResult], result)).cancel()
+        if current_async_library() == "asyncio":
+            ensure_future(cast(Awaitable[ExecutionResult], result)).cancel()
         raise RuntimeError("GraphQL execution failed to complete synchronously.")
 
     return cast(ExecutionResult, result)

--- a/src/graphql/pyutils/__init__.py
+++ b/src/graphql/pyutils/__init__.py
@@ -32,6 +32,7 @@ from .merge_kwargs import merge_kwargs
 from .path import Path
 from .print_path_list import print_path_list
 from .simple_pub_sub import SimplePubSub, SimplePubSubIterator
+from .broadcast_stream import MemoryObjectBroadcastStream, create_broadcast_stream
 from .undefined import Undefined, UndefinedType
 
 __all__ = [
@@ -60,6 +61,8 @@ __all__ = [
     "print_path_list",
     "SimplePubSub",
     "SimplePubSubIterator",
+    "MemoryObjectBroadcastStream",
+    "create_broadcast_stream",
     "Undefined",
     "UndefinedType",
 ]

--- a/src/graphql/pyutils/broadcast_stream.py
+++ b/src/graphql/pyutils/broadcast_stream.py
@@ -1,0 +1,148 @@
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Type, Callable
+from types import TracebackType
+
+import anyio
+from anyio.streams.memory import MemoryObjectSendStream, MemoryObjectReceiveStream
+
+__all__ = ["MemoryObjectBroadcastStream", "create_broadcast_stream"]
+
+
+def create_broadcast_stream(
+    max_buffer_size: float, requires_listeners: bool = False
+) -> "MemoryObjectBroadcastStream":
+    return MemoryObjectBroadcastStream(
+        BroadcastStreamState(max_buffer_size, requires_listeners)
+    )
+
+
+@dataclass
+class BroadcastStreamListener:
+    stream: MemoryObjectSendStream
+    transform: Optional[Callable[[Any], Any]] = None
+
+
+@dataclass
+class BroadcastStreamState:
+    max_buffer_size: float
+    requires_listeners: bool
+    listeners: List[BroadcastStreamListener] = field(default_factory=list)
+    ref_counter: int = 0
+
+
+class MemoryObjectBroadcastStream:
+    _state: BroadcastStreamState
+    _closed: bool
+
+    def __init__(self, state: BroadcastStreamState):
+        self._state = state
+        self._closed = False
+        self._state.ref_counter += 1
+
+    async def aclose(self) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if not self._closed:
+            self._closed = True
+            self._state.ref_counter -= 1
+            if self._state.ref_counter == 0:
+                for listener in self._state.listeners:
+                    listener.stream.close()
+                self._state.listeners = []
+
+    def clone(self) -> "MemoryObjectBroadcastStream":
+        if self._closed:
+            raise anyio.ClosedResourceError
+        return MemoryObjectBroadcastStream(self._state)
+
+    async def _send_to_listener(
+        self, listener: BroadcastStreamListener, item: Any
+    ) -> None:
+        try:
+            if listener.transform is not None:
+                item = listener.transform(item)
+            await listener.stream.send(item)
+        except (anyio.ClosedResourceError, anyio.BrokenResourceError):
+            with anyio.CancelScope(shield=True):
+                await listener.stream.aclose()
+                self._state.listeners.remove(listener)
+
+    async def send(self, item: Any) -> bool:
+        if self._closed:
+            raise anyio.ClosedResourceError
+        async with anyio.create_task_group() as tg:
+            for listener in self._state.listeners:
+                tg.start_soon(self._send_to_listener, listener, item)
+        if not self._state.listeners:
+            if self._state.requires_listeners:
+                raise anyio.BrokenResourceError
+            return False
+        return True
+
+    def send_nowait(self, item: Any) -> bool:
+        if self._closed:
+            raise anyio.ClosedResourceError
+        for listener in list(self._state.listeners):
+            stats = listener.stream.statistics()
+            if stats.open_receive_streams == 0:
+                listener.stream.close()
+                self._state.listeners.remove(listener)
+            # We raise WouldBlock before sending anything
+            if (
+                stats.max_buffer_size <= stats.current_buffer_used
+                and not stats.tasks_waiting_send
+            ):
+                raise anyio.WouldBlock
+
+        for listener in self._state.listeners:
+            try:
+                if listener.transform is not None:
+                    listener.stream.send_nowait(listener.transform(item))
+                else:
+                    listener.stream.send_nowait(item)
+            except (
+                anyio.ClosedResourceError,
+                anyio.BrokenResourceError,
+            ):  # pragma: no cover
+                # we checked all listeners beforehand, this should not happen
+                listener.stream.close()
+                self._state.listeners.remove(listener)
+            except anyio.WouldBlock:  # pragma: no cover
+                assert (
+                    False  # we checked all listeners beforehand, this should not happen
+                )
+        if not self._state.listeners:
+            if self._state.requires_listeners:
+                raise anyio.BrokenResourceError
+            return False
+        return True
+
+    def get_listener(
+        self, transform: Optional[Callable[[Any], Any]] = None
+    ) -> MemoryObjectReceiveStream:
+        send, receive = anyio.create_memory_object_stream(self._state.max_buffer_size)
+        self._state.listeners.append(BroadcastStreamListener(send, transform))
+        return receive
+
+    def __enter__(self) -> "MemoryObjectBroadcastStream":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.close()
+
+    async def __aenter__(self) -> "MemoryObjectBroadcastStream":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.close()

--- a/src/graphql/pyutils/simple_pub_sub.py
+++ b/src/graphql/pyutils/simple_pub_sub.py
@@ -17,6 +17,8 @@ class SimplePubSub:
     Creates an AsyncIterator from an EventEmitter.
 
     Useful for mocking a PubSub system for tests.
+
+    Warning: Only works with an asyncio event loop.
     """
 
     subscribers: Set[Callable]
@@ -39,6 +41,10 @@ class SimplePubSub:
 
 
 class SimplePubSubIterator(AsyncIterator):
+    """
+    Warning: Only works with an asyncio event loop.
+    """
+
     def __init__(self, pubsub: SimplePubSub, transform: Optional[Callable]) -> None:
         self.pubsub = pubsub
         self.transform = transform

--- a/src/graphql/utilities/ast_from_value.py
+++ b/src/graphql/utilities/ast_from_value.py
@@ -118,7 +118,7 @@ def ast_from_value(value: Any, type_: GraphQLInputType) -> Optional[ValueNode]:
             return IntValueNode(value=str(serialized))
         if isinstance(serialized, float) and isfinite(serialized):
             value = str(serialized)
-            if value.endswith('.0'):
+            if value.endswith(".0"):
                 value = value[:-2]
             return FloatValueNode(value=value)
 

--- a/tests/benchmarks/test_execution_async.py
+++ b/tests/benchmarks/test_execution_async.py
@@ -64,7 +64,8 @@ def test_execute_basic_async(anyio_backend, benchmark):
 
 @mark.parametrize("anyio_backend", ["trio"])
 def test_execute_basic_async_trio(anyio_backend, benchmark):
-    # TODO: can the trio loop be started beforehand? run benchmark in async function somehow?
+    # TODO: can the trio loop be started beforehand?
+    # Can the benchmark be run in an async function somehow?
     import trio
 
     result = benchmark(lambda: trio.run(graphql, schema, "query { user { id, name }}"))

--- a/tests/benchmarks/test_execution_async.py
+++ b/tests/benchmarks/test_execution_async.py
@@ -1,4 +1,7 @@
 import asyncio
+
+from pytest import mark
+
 from graphql import (
     GraphQLSchema,
     GraphQLObjectType,
@@ -37,7 +40,10 @@ schema = GraphQLSchema(
 )
 
 
-def test_execute_basic_async(benchmark):
+@mark.parametrize("anyio_backend", ["asyncio"])
+def test_execute_basic_async(anyio_backend, benchmark):
+    # Note: test too low level for anyio, duplicated test for trio below
+
     # Note: we are creating the async loop outside of the benchmark code so that
     # the setup is not included in the benchmark timings
     loop = asyncio.events.new_event_loop()
@@ -47,6 +53,21 @@ def test_execute_basic_async(benchmark):
     )
     asyncio.events.set_event_loop(None)
     loop.close()
+    assert not result.errors
+    assert result.data == {
+        "user": {
+            "id": "1",
+            "name": "Sarah",
+        },
+    }
+
+
+@mark.parametrize("anyio_backend", ["trio"])
+def test_execute_basic_async_trio(anyio_backend, benchmark):
+    # TODO: can the trio loop be started beforehand? run benchmark in async function somehow?
+    import trio
+
+    result = benchmark(lambda: trio.run(graphql, schema, "query { user { id, name }}"))
     assert not result.errors
     assert result.data == {
         "user": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,21 @@
 # pytest configuration
 
+import sys
+
 import pytest
+
+if sys.version_info >= (3, 7):
+    event_loops = [
+        pytest.param(("asyncio"), id="asyncio"),
+        pytest.param(("trio"), id="trio"),
+    ]
+else:
+    event_loops = [pytest.param(("asyncio"), id="asyncio")]
+
+
+@pytest.fixture(params=event_loops)
+def anyio_backend(request):
+    return request.param
 
 
 def pytest_addoption(parser):

--- a/tests/execution/test_abstract.py
+++ b/tests/execution/test_abstract.py
@@ -20,14 +20,14 @@ from graphql.utilities import build_schema
 
 def sync_and_async(spec):
     """Decorator for running a test synchronously and asynchronously."""
-    return mark.asyncio(
+    return mark.anyio(
         mark.parametrize("sync", (True, False), ids=("sync", "async"))(spec)
     )
 
 
 def access_variants(spec):
     """Decorator for tests with dict and object access, including inheritance."""
-    return mark.asyncio(
+    return mark.anyio(
         mark.parametrize("access", ("dict", "object", "inheritance"))(spec)
     )
 

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -1,4 +1,4 @@
-import asyncio
+import anyio
 from typing import cast, Any, Awaitable, Optional
 
 from pytest import mark, raises
@@ -91,7 +91,7 @@ def describe_execute_handles_basic_execution_tasks():
 
         assert result == ({"a": "rootValue"}, None)
 
-    @mark.asyncio
+    @mark.anyio
     async def executes_arbitrary_code():
         # noinspection PyMethodMayBeStatic,PyMethodMayBeStatic
         class Data:
@@ -137,7 +137,7 @@ def describe_execute_handles_basic_execution_tasks():
                 return [Data(), None, Data()]
 
         async def promise_data():
-            await asyncio.sleep(0)
+            await anyio.sleep(0)
             return Data()
 
         DeepDataType: GraphQLObjectType
@@ -422,7 +422,7 @@ def describe_execute_handles_basic_execution_tasks():
         assert len(resolved_args) == 1
         assert resolved_args[0] == {"numArg": 123, "stringArg": "foo"}
 
-    @mark.asyncio
+    @mark.anyio
     async def nulls_out_error_subtrees():
         document = parse(
             """
@@ -832,7 +832,7 @@ def describe_execute_handles_basic_execution_tasks():
             ],
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def correct_field_ordering_despite_execution_order():
         schema = GraphQLSchema(
             GraphQLObjectType(
@@ -948,7 +948,7 @@ def describe_execute_handles_basic_execution_tasks():
             None,
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def fails_when_is_type_of_check_is_not_met():
         class Special:
             value: str

--- a/tests/execution/test_lists.py
+++ b/tests/execution/test_lists.py
@@ -117,7 +117,7 @@ def describe_execute_handles_list_nullability():
 
         return result
 
-    @mark.asyncio
+    @mark.anyio
     async def contains_values():
         list_field = [1, 2]
         assert await _complete(list_field, "[Int]") == ({"listField": [1, 2]}, None)
@@ -125,7 +125,7 @@ def describe_execute_handles_list_nullability():
         assert await _complete(list_field, "[Int!]") == ({"listField": [1, 2]}, None)
         assert await _complete(list_field, "[Int!]!") == ({"listField": [1, 2]}, None)
 
-    @mark.asyncio
+    @mark.anyio
     async def contains_null():
         list_field = [1, None, 2]
         errors = [
@@ -146,7 +146,7 @@ def describe_execute_handles_list_nullability():
         assert await _complete(list_field, "[Int!]") == ({"listField": None}, errors)
         assert await _complete(list_field, "[Int!]!") == (None, errors)
 
-    @mark.asyncio
+    @mark.anyio
     async def returns_null():
         list_field = None
         errors = [
@@ -161,7 +161,7 @@ def describe_execute_handles_list_nullability():
         assert await _complete(list_field, "[Int!]") == ({"listField": None}, None)
         assert await _complete(list_field, "[Int!]!") == (None, errors)
 
-    @mark.asyncio
+    @mark.anyio
     async def contains_error():
         list_field = [1, RuntimeError("bad"), 2]
         errors = [
@@ -188,7 +188,7 @@ def describe_execute_handles_list_nullability():
             errors,
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def results_in_errors():
         list_field = RuntimeError("bad")
         errors = [
@@ -227,7 +227,7 @@ def describe_experimental_execute_accepts_async_iterables_as_list_value():
         result = cast(Awaitable, result)
         return await result
 
-    @mark.asyncio
+    @mark.anyio
     async def accepts_an_async_generator_as_a_list_value():
         async def list_field():
             yield "one"
@@ -239,7 +239,7 @@ def describe_experimental_execute_accepts_async_iterables_as_list_value():
             None,
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def accepts_a_custom_async_iterable_as_a_list_value():
         class ListField:
             def __aiter__(self):

--- a/tests/execution/test_map_async_iterator.py
+++ b/tests/execution/test_map_async_iterator.py
@@ -1,5 +1,5 @@
 import sys
-from asyncio import CancelledError, Event, ensure_future, sleep
+from anyio import create_task_group, get_cancelled_exc_class, sleep, Event
 
 from pytest import mark, raises
 
@@ -16,7 +16,7 @@ except NameError:  # pragma: no cover (Python < 3.10)
 
 
 def describe_map_async_iterator():
-    @mark.asyncio
+    @mark.anyio
     async def maps_over_async_generator():
         async def source():
             yield 1
@@ -31,7 +31,7 @@ def describe_map_async_iterator():
         with raises(StopAsyncIteration):
             assert await anext(doubles)
 
-    @mark.asyncio
+    @mark.anyio
     async def maps_over_async_iterable():
         items = [1, 2, 3]
 
@@ -52,7 +52,7 @@ def describe_map_async_iterator():
         assert not items
         assert values == [2, 4, 6]
 
-    @mark.asyncio
+    @mark.anyio
     async def compatible_with_async_for():
         async def source():
             yield 1
@@ -65,7 +65,7 @@ def describe_map_async_iterator():
 
         assert values == [2, 4, 6]
 
-    @mark.asyncio
+    @mark.anyio
     async def maps_over_async_values_with_async_function():
         async def source():
             yield 1
@@ -81,7 +81,7 @@ def describe_map_async_iterator():
 
         assert values == [2, 4, 6]
 
-    @mark.asyncio
+    @mark.anyio
     async def allows_returning_early_from_mapped_async_generator():
         async def source():
             yield 1
@@ -102,7 +102,7 @@ def describe_map_async_iterator():
         with raises(StopAsyncIteration):
             await anext(doubles)
 
-    @mark.asyncio
+    @mark.anyio
     async def allows_returning_early_from_mapped_async_iterable():
         items = [1, 2, 3]
 
@@ -130,7 +130,7 @@ def describe_map_async_iterator():
         with raises(StopAsyncIteration):
             await anext(doubles)
 
-    @mark.asyncio
+    @mark.anyio
     async def passes_through_early_return_from_async_values():
         async def source():
             try:
@@ -154,7 +154,7 @@ def describe_map_async_iterator():
         with raises(GeneratorExit):
             assert await anext(doubles)
 
-    @mark.asyncio
+    @mark.anyio
     async def allows_throwing_errors_through_async_iterable():
         items = [1, 2, 3]
 
@@ -184,7 +184,7 @@ def describe_map_async_iterator():
         with raises(StopAsyncIteration):
             await anext(doubles)
 
-    @mark.asyncio
+    @mark.anyio
     async def allows_throwing_errors_with_values_through_async_iterators():
         class Iterator:
             def __aiter__(self):
@@ -210,7 +210,7 @@ def describe_map_async_iterator():
         with raises(StopAsyncIteration):
             await anext(one)
 
-    @mark.asyncio
+    @mark.anyio
     async def allows_throwing_errors_with_traceback_through_async_iterators():
         class Iterator:
             def __aiter__(self):
@@ -236,7 +236,7 @@ def describe_map_async_iterator():
         with raises(StopAsyncIteration):
             await anext(one)
 
-    @mark.asyncio
+    @mark.anyio
     async def passes_through_caught_errors_through_async_generators():
         async def source():
             try:
@@ -259,7 +259,7 @@ def describe_map_async_iterator():
         with raises(StopAsyncIteration):
             await anext(doubles)
 
-    @mark.asyncio
+    @mark.anyio
     async def does_not_normally_map_over_thrown_errors():
         async def source():
             yield "Hello"
@@ -274,7 +274,7 @@ def describe_map_async_iterator():
 
         assert str(exc_info.value) == "Goodbye"
 
-    @mark.asyncio
+    @mark.anyio
     async def does_not_normally_map_over_externally_thrown_errors():
         async def source():
             yield "Hello"
@@ -288,7 +288,7 @@ def describe_map_async_iterator():
 
         assert str(exc_info.value) == "Goodbye"
 
-    @mark.asyncio
+    @mark.anyio
     async def can_use_simple_iterator_instead_of_generator():
         async def source():
             yield 1
@@ -367,7 +367,7 @@ def describe_map_async_iterator():
 
         await sleep(0)
 
-    @mark.asyncio
+    @mark.anyio
     async def stops_async_iteration_on_close():
         async def source():
             yield 1
@@ -381,21 +381,35 @@ def describe_map_async_iterator():
         result = await anext(doubles)
         assert result == 2
 
-        # Make sure it is blocked
-        doubles_future = ensure_future(anext(doubles))
-        await sleep(0.05)
-        assert not doubles_future.done()
+        done = False
 
-        # Unblock and watch StopAsyncIteration propagate
-        await doubles.aclose()
-        await sleep(0.05)
-        assert doubles_future.done()
-        assert isinstance(doubles_future.exception(), StopAsyncIteration)
+        async def set_done():
+            nonlocal done
+            try:
+                await anext(doubles)
+            except StopAsyncIteration:
+                done = True
+                raise
+
+        with raises(StopAsyncIteration):
+            async with create_task_group() as tg:
+                # Make sure it is blocked
+                tg.start_soon(set_done)
+                await sleep(0.05)
+                assert not done
+
+                # Unblock and watch StopAsyncIteration propagate
+                try:
+                    await doubles.aclose()
+                except:
+                    assert False  # ensure that aclose does not raise a StopAsyncIteration
+                    
+        assert done
 
         with raises(StopAsyncIteration):
             await anext(singles)
 
-    @mark.asyncio
+    @mark.anyio
     async def can_unset_closed_state_of_async_iterator():
         items = [1, 2, 3]
 
@@ -445,7 +459,7 @@ def describe_map_async_iterator():
         assert not doubles.is_closed
         assert not iterator.is_closed
 
-    @mark.asyncio
+    @mark.anyio
     async def can_cancel_async_iterator_while_waiting():
         class Iterator:
             def __init__(self):
@@ -459,7 +473,7 @@ def describe_map_async_iterator():
                 try:
                     await sleep(0.5)
                     return self.value  # pragma: no cover
-                except CancelledError:
+                except get_cancelled_exc_class():
                     self.value = -1
                     raise
 
@@ -475,17 +489,18 @@ def describe_map_async_iterator():
             try:
                 async for _ in doubles:
                     assert False  # pragma: no cover
-            except CancelledError:
+            except get_cancelled_exc_class():
                 cancelled = True
 
-        task = ensure_future(iterator_task())
-        await sleep(0.05)
-        assert not cancelled
-        assert not doubles.is_closed
-        assert iterator.value == 1
-        assert not iterator.is_closed
-        task.cancel()
-        await sleep(0.05)
+        async with create_task_group() as tg:
+            tg.start_soon(iterator_task)
+            await sleep(0.05)
+            assert not cancelled
+            assert not doubles.is_closed
+            assert iterator.value == 1
+            assert not iterator.is_closed
+            tg.cancel_scope.cancel()
+
         assert cancelled
         assert iterator.value == -1
         assert doubles.is_closed

--- a/tests/execution/test_middleware.py
+++ b/tests/execution/test_middleware.py
@@ -90,7 +90,7 @@ def describe_middleware():
 
             assert result.data == {"first": "Eno", "second": "Owt"}  # type: ignore
 
-        @mark.asyncio
+        @mark.anyio
         async def single_async_function():
             doc = parse("{ first second }")
 
@@ -202,7 +202,7 @@ def describe_middleware():
             )
             assert result.data == {"field": "devloseR"}  # type: ignore
 
-        @mark.asyncio
+        @mark.anyio
         async def with_async_function_and_object():
             doc = parse("{ field }")
 

--- a/tests/execution/test_mutations.py
+++ b/tests/execution/test_mutations.py
@@ -1,4 +1,4 @@
-import asyncio
+import anyio
 from typing import Awaitable
 
 from pytest import mark
@@ -36,14 +36,14 @@ class Root:
         return self.numberHolder
 
     async def promise_to_change_the_number(self, new_number: int) -> NumberHolder:
-        await asyncio.sleep(0)
+        await anyio.sleep(0)
         return self.immediately_change_the_number(new_number)
 
     def fail_to_change_the_number(self, newNumber: int):
         raise RuntimeError(f"Cannot change the number to {newNumber}")
 
     async def promise_and_fail_to_change_the_number(self, newNumber: int):
-        await asyncio.sleep(0)
+        await anyio.sleep(0)
         self.fail_to_change_the_number(newNumber)
 
 
@@ -91,7 +91,7 @@ schema = GraphQLSchema(
 
 
 def describe_execute_handles_mutation_execution_ordering():
-    @mark.asyncio
+    @mark.anyio
     async def evaluates_mutations_serially():
         document = parse(
             """
@@ -139,7 +139,7 @@ def describe_execute_handles_mutation_execution_ordering():
         result = execute_sync(schema=schema, document=document)
         assert result == ({}, None)
 
-    @mark.asyncio
+    @mark.anyio
     async def evaluates_mutations_correctly_in_presence_of_a_failed_mutation():
         document = parse(
             """

--- a/tests/execution/test_nonnull.py
+++ b/tests/execution/test_nonnull.py
@@ -125,12 +125,12 @@ def describe_execute_handles_non_nullable_types():
             }
             """
 
-        @mark.asyncio
+        @mark.anyio
         async def returns_null():
             result = await execute_sync_and_async(query, NullingData())
             assert result == ({"sync": None}, None)
 
-        @mark.asyncio
+        @mark.anyio
         async def throws():
             result = await execute_sync_and_async(query, ThrowingData())
             assert result == (
@@ -154,7 +154,7 @@ def describe_execute_handles_non_nullable_types():
             }
             """
 
-        @mark.asyncio
+        @mark.anyio
         async def that_returns_null():
             result = await execute_sync_and_async(query, NullingData())
             assert result == (
@@ -169,7 +169,7 @@ def describe_execute_handles_non_nullable_types():
                 ],
             )
 
-        @mark.asyncio
+        @mark.anyio
         async def that_throws():
             result = await execute_sync_and_async(query, ThrowingData())
             assert result == (
@@ -215,14 +215,14 @@ def describe_execute_handles_non_nullable_types():
             },
         }
 
-        @mark.asyncio
+        @mark.anyio
         async def returns_null():
             result = await cast(
                 Awaitable[ExecutionResult], execute_query(query, NullingData())
             )
             assert result == (data, None)
 
-        @mark.asyncio
+        @mark.anyio
         async def throws():
             result = await cast(
                 Awaitable[ExecutionResult], execute_query(query, ThrowingData())
@@ -349,7 +349,7 @@ def describe_execute_handles_non_nullable_types():
             "anotherPromiseNest": None,
         }
 
-        @mark.asyncio
+        @mark.anyio
         async def returns_null():
             result = await cast(
                 Awaitable[ExecutionResult], execute_query(query, NullingData())
@@ -412,7 +412,7 @@ def describe_execute_handles_non_nullable_types():
                 ],
             )
 
-        @mark.asyncio
+        @mark.anyio
         async def throws():
             result = await cast(
                 Awaitable[ExecutionResult], execute_query(query, ThrowingData())
@@ -478,7 +478,7 @@ def describe_execute_handles_non_nullable_types():
             }
             """
 
-        @mark.asyncio
+        @mark.anyio
         async def returns_null():
             result = await execute_sync_and_async(query, NullingData())
             assert result == (
@@ -493,7 +493,7 @@ def describe_execute_handles_non_nullable_types():
                 ],
             )
 
-        @mark.asyncio
+        @mark.anyio
         async def throws():
             result = await execute_sync_and_async(query, ThrowingData())
             assert result == (

--- a/tests/execution/test_subscribe.py
+++ b/tests/execution/test_subscribe.py
@@ -1,4 +1,4 @@
-import asyncio
+import anyio
 
 from typing import Any, Dict, List, Callable
 
@@ -121,7 +121,7 @@ DummyQueryType = GraphQLObjectType("Query", {"dummy": GraphQLField(GraphQLString
 
 # Check all error cases when initializing the subscription.
 def describe_subscription_initialization_phase():
-    @mark.asyncio
+    @mark.anyio
     async def accepts_positional_arguments():
         document = parse(
             """
@@ -143,7 +143,7 @@ def describe_subscription_initialization_phase():
             await anext(ai)
         await ai.aclose()  # type: ignore
 
-    @mark.asyncio
+    @mark.anyio
     async def accepts_multiple_subscription_fields_defined_in_schema():
         schema = GraphQLSchema(
             query=DummyQueryType,
@@ -168,7 +168,7 @@ def describe_subscription_initialization_phase():
 
         await subscription.aclose()
 
-    @mark.asyncio
+    @mark.anyio
     async def accepts_type_definition_with_sync_subscribe_function():
         async def foo_generator(_obj, _info):
             yield {"foo": "FooValue"}
@@ -188,10 +188,10 @@ def describe_subscription_initialization_phase():
 
         await subscription.aclose()
 
-    @mark.asyncio
+    @mark.anyio
     async def accepts_type_definition_with_async_subscribe_function():
         async def foo_generator(_obj, _info):
-            await asyncio.sleep(0)
+            await anyio.sleep(0)
             yield {"foo": "FooValue"}
 
         schema = GraphQLSchema(
@@ -209,7 +209,7 @@ def describe_subscription_initialization_phase():
 
         await subscription.aclose()
 
-    @mark.asyncio
+    @mark.anyio
     async def uses_a_custom_default_subscribe_field_resolver():
         schema = GraphQLSchema(
             query=DummyQueryType,
@@ -238,7 +238,7 @@ def describe_subscription_initialization_phase():
 
         await subscription.aclose()
 
-    @mark.asyncio
+    @mark.anyio
     async def should_only_resolve_the_first_field_of_invalid_multi_field():
         did_resolve = {"foo": False, "bar": False}
 
@@ -273,7 +273,7 @@ def describe_subscription_initialization_phase():
 
         await subscription.aclose()
 
-    @mark.asyncio
+    @mark.anyio
     async def throws_an_error_if_some_of_required_arguments_are_missing():
         document = parse("subscription { foo }")
 
@@ -296,7 +296,7 @@ def describe_subscription_initialization_phase():
         with raises(TypeError, match="missing .* positional argument: 'document'"):
             await subscribe(schema=schema)  # type: ignore
 
-    @mark.asyncio
+    @mark.anyio
     async def resolves_to_an_error_if_schema_does_not_support_subscriptions():
         schema = GraphQLSchema(query=DummyQueryType)
         document = parse("subscription { unknownField }")
@@ -314,7 +314,7 @@ def describe_subscription_initialization_phase():
             ],
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def resolves_to_an_error_for_unknown_subscription_field():
         schema = GraphQLSchema(
             query=DummyQueryType,
@@ -335,7 +335,7 @@ def describe_subscription_initialization_phase():
             ],
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def should_pass_through_unexpected_errors_thrown_in_subscribe():
         schema = GraphQLSchema(
             query=DummyQueryType,
@@ -346,7 +346,7 @@ def describe_subscription_initialization_phase():
         with raises(TypeError, match="^Must provide document\\.$"):
             await subscribe(schema=schema, document={})  # type: ignore
 
-    @mark.asyncio
+    @mark.anyio
     @mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
     async def throws_an_error_if_subscribe_does_not_return_an_iterator():
         schema = GraphQLSchema(
@@ -370,7 +370,7 @@ def describe_subscription_initialization_phase():
             "Subscription field must return AsyncIterable. Received: 'test'."
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def resolves_to_an_error_for_subscription_resolver_errors():
         async def subscribe_with_fn(subscribe_fn: Callable):
             schema = GraphQLSchema(
@@ -421,7 +421,7 @@ def describe_subscription_initialization_phase():
 
         assert await subscribe_with_fn(reject_error) == expected_result
 
-    @mark.asyncio
+    @mark.anyio
     async def resolves_to_an_error_if_variables_were_wrong_type():
         schema = GraphQLSchema(
             query=DummyQueryType,
@@ -464,7 +464,7 @@ def describe_subscription_initialization_phase():
 
 # Once a subscription returns a valid AsyncIterator, it can still yield errors.
 def describe_subscription_publish_phase():
-    @mark.asyncio
+    @mark.anyio
     async def produces_a_payload_for_multiple_subscribe_in_same_subscription():
         pubsub = SimplePubSub()
 
@@ -499,7 +499,7 @@ def describe_subscription_publish_phase():
         assert await payload1 == (expected_payload, None)
         assert await payload2 == (expected_payload, None)
 
-    @mark.asyncio
+    @mark.anyio
     async def produces_a_payload_per_subscription_event():
         pubsub = SimplePubSub()
         subscription = await create_subscription(pubsub)
@@ -577,7 +577,7 @@ def describe_subscription_publish_phase():
         with raises(StopAsyncIteration):
             assert await anext(subscription)
 
-    @mark.asyncio
+    @mark.anyio
     async def produces_a_payload_when_there_are_multiple_events():
         pubsub = SimplePubSub()
         subscription = await create_subscription(pubsub)
@@ -633,7 +633,7 @@ def describe_subscription_publish_phase():
             None,
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def should_not_trigger_when_subscription_is_already_done():
         pubsub = SimplePubSub()
         subscription = await create_subscription(pubsub)
@@ -683,7 +683,7 @@ def describe_subscription_publish_phase():
         with raises(StopAsyncIteration):
             await payload
 
-    @mark.asyncio
+    @mark.anyio
     async def should_not_trigger_when_subscription_is_thrown():
         pubsub = SimplePubSub()
         subscription = await create_subscription(pubsub)
@@ -724,7 +724,7 @@ def describe_subscription_publish_phase():
         with raises(StopAsyncIteration):
             await payload
 
-    @mark.asyncio
+    @mark.anyio
     async def event_order_is_correct_for_multiple_publishes():
         pubsub = SimplePubSub()
         subscription = await create_subscription(pubsub)
@@ -780,7 +780,7 @@ def describe_subscription_publish_phase():
             None,
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def should_handle_error_during_execution_of_source_event():
         async def generate_messages(_obj, _info):
             yield "Hello"
@@ -828,7 +828,7 @@ def describe_subscription_publish_phase():
         # Subsequent events are still executed.
         assert await anext(subscription) == ({"newMessage": "Bonjour"}, None)
 
-    @mark.asyncio
+    @mark.anyio
     async def should_pass_through_error_thrown_in_source_event_stream():
         async def generate_messages(_obj, _info):
             yield "Hello"
@@ -865,7 +865,7 @@ def describe_subscription_publish_phase():
         with raises(StopAsyncIteration):
             await anext(subscription)
 
-    @mark.asyncio
+    @mark.anyio
     async def should_work_with_async_resolve_function():
         async def generate_messages(_obj, _info):
             yield "Hello"

--- a/tests/execution/test_sync.py
+++ b/tests/execution/test_sync.py
@@ -52,7 +52,7 @@ def describe_execute_synchronously_when_possible():
             None,
         )
 
-    @mark.asyncio
+    @mark.anyio
     async def returns_an_awaitable_if_any_field_is_asynchronous():
         doc = "query Example { syncField, asyncField }"
         result = execute(schema, parse(doc), "rootValue")
@@ -81,7 +81,7 @@ def describe_execute_synchronously_when_possible():
                 None,
             )
 
-        @mark.asyncio
+        @mark.anyio
         @mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
         async def throws_if_encountering_async_execution_with_check_sync():
             doc = "query Example { syncField, asyncField }"
@@ -92,7 +92,7 @@ def describe_execute_synchronously_when_possible():
             msg = str(exc_info.value)
             assert msg == "GraphQL execution failed to complete synchronously."
 
-        @mark.asyncio
+        @mark.anyio
         @mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
         async def throws_if_encountering_async_operation_without_check_sync():
             doc = "query Example { syncField, asyncField }"
@@ -150,7 +150,7 @@ def describe_execute_synchronously_when_possible():
                 None,
             )
 
-        @mark.asyncio
+        @mark.anyio
         @mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
         async def throws_if_encountering_async_operation_with_check_sync():
             doc = "query Example { syncField, asyncField }"
@@ -159,7 +159,7 @@ def describe_execute_synchronously_when_possible():
             msg = str(exc_info.value)
             assert msg == "GraphQL execution failed to complete synchronously."
 
-        @mark.asyncio
+        @mark.anyio
         @mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
         async def throws_if_encountering_async_operation_without_check_sync():
             doc = "query Example { syncField, asyncField }"

--- a/tests/pyutils/test_broadcast_stream.py
+++ b/tests/pyutils/test_broadcast_stream.py
@@ -1,0 +1,192 @@
+from anyio import (
+    sleep,
+    fail_after,
+    create_task_group,
+    Event,
+    ClosedResourceError,
+    WouldBlock,
+    BrokenResourceError,
+)
+import math
+
+from pytest import mark, raises
+
+from graphql.pyutils import create_broadcast_stream
+
+
+def describe_broadcast_stream():
+    @mark.anyio
+    async def subscribe_async_iterator_mock():
+        pubsub = create_broadcast_stream(math.inf)
+        iterator = pubsub.get_listener()
+
+        with fail_after(1):
+            # Queue up publishes
+            assert pubsub.send_nowait("Apple") is True
+            assert pubsub.send_nowait("Banana") is True
+
+            # Read payloads
+            assert await iterator.__anext__() == "Apple"
+            assert await iterator.__anext__() == "Banana"
+
+            # Waiting for data
+            is_waiting = Event()
+            i3 = None
+            i4 = None
+
+            async def wait_for_next():
+                nonlocal i3, i4
+                is_waiting.set()
+                i3 = await iterator.__anext__()
+                i4 = await iterator.__anext__()
+
+            async with create_task_group() as tg:
+                tg.start_soon(wait_for_next)
+                await is_waiting.wait()
+                await sleep(0.1)
+                # Publish
+                assert pubsub.send_nowait("Coconut") is True
+                assert pubsub.send_nowait("Durian") is True
+
+            assert i3 == "Coconut"
+            assert i4 == "Durian"
+
+            # Terminate queue
+            await iterator.aclose()
+
+            # Publish is not caught after terminate
+            assert pubsub.send_nowait("Fig") is False
+
+            with raises(ClosedResourceError):
+                await iterator.__anext__()
+
+    @mark.anyio
+    async def iterator_aclose_closes_listeners():
+        pubsub = create_broadcast_stream(math.inf)
+        assert not pubsub._state.listeners
+        iterator = pubsub.get_listener()
+        assert len(pubsub._state.listeners) == 1
+
+        for value in range(3):
+            pubsub.send_nowait(value)
+        await sleep(0)
+        await iterator.aclose()
+        assert pubsub.send_nowait(value) is False  # listeners closed on next send
+        assert not pubsub._state.listeners
+
+    @mark.anyio
+    async def stream_aclose_closes_listeners():
+        pubsub = create_broadcast_stream(math.inf)
+        iterator = pubsub.get_listener()
+        await pubsub.aclose()
+        with fail_after(1):
+            async for el in iterator:
+                pass
+
+    @mark.anyio
+    async def multiple_listeners_get_object():
+        pubsub = create_broadcast_stream(math.inf)
+        iterator1 = pubsub.get_listener()
+        pubsub.send_nowait("A")
+        iterator2 = pubsub.get_listener()
+        pubsub.send_nowait("B")
+        pubsub.send_nowait("C")
+        await pubsub.aclose()
+        await pubsub.aclose()  # idempotent
+        with fail_after(1):
+            assert ["A", "B", "C"] == [el async for el in iterator1]
+            assert ["B", "C"] == [el async for el in iterator2]
+
+    @mark.anyio
+    async def cloned_broadcast():
+        pubsub1 = create_broadcast_stream(math.inf)
+        pubsub2 = pubsub1.clone()
+        iterator1 = pubsub1.get_listener()
+        pubsub2.send_nowait("A")
+        iterator2 = pubsub2.get_listener()
+        pubsub1.send_nowait("B")
+        pubsub2.send_nowait("C")
+
+        assert pubsub2._state.ref_counter == 2
+        await pubsub1.aclose()
+        assert pubsub2._state.ref_counter == 1
+        # check expected errors after close
+        with raises(ClosedResourceError):
+            pubsub1.send_nowait("D")
+        with raises(ClosedResourceError):
+            await pubsub1.send("D")
+        with raises(ClosedResourceError):
+            pubsub1.clone()
+
+        # idempotent close
+        assert pubsub2._state.ref_counter == 1
+        await pubsub1.aclose()
+        assert pubsub2._state.ref_counter == 1
+        pubsub2.send_nowait("E")
+
+        await pubsub2.aclose()
+        with fail_after(1):
+            assert ["A", "B", "C", "E"] == [el async for el in iterator1]
+            assert ["B", "C", "E"] == [el async for el in iterator2]
+
+    def blocking_stream():
+        pubsub = create_broadcast_stream(0)
+        pubsub.send_nowait("A")  # no listener
+
+        pubsub.get_listener()
+        with raises(WouldBlock):
+            pubsub.send_nowait("B")
+
+    @mark.anyio
+    async def close_listeners():
+        pubsub = create_broadcast_stream(math.inf)
+        iterator = pubsub.get_listener()
+        assert pubsub._state.listeners
+        await iterator.aclose()
+        pubsub.send_nowait("A")
+        assert not pubsub._state.listeners
+
+    @mark.anyio
+    async def requires_listeners():
+        pubsub = create_broadcast_stream(math.inf, requires_listeners=True)
+        with raises(BrokenResourceError):
+            pubsub.send_nowait("A")
+
+        iterator = pubsub.get_listener()
+        assert pubsub._state.listeners
+        await iterator.aclose()
+        with raises(BrokenResourceError):
+            pubsub.send_nowait("B")
+        assert not pubsub._state.listeners
+
+        iterator = pubsub.get_listener()
+        assert pubsub._state.listeners
+        await iterator.aclose()
+        with raises(BrokenResourceError):
+            await pubsub.send("C")
+        assert not pubsub._state.listeners
+
+    @mark.anyio
+    async def transformation():
+        pubsub = create_broadcast_stream(math.inf)
+        iterator1 = pubsub.get_listener(transform=lambda el: 2 * el)
+        pubsub.send_nowait(1)
+        iterator2 = pubsub.get_listener(transform=lambda el: 3 * el)
+        pubsub.send_nowait(2)
+        pubsub.send_nowait(3)
+        await pubsub.aclose()
+        with fail_after(1):
+            assert [2, 4, 6] == [el async for el in iterator1]
+            assert [6, 9] == [el async for el in iterator2]
+
+    @mark.anyio
+    async def context_manager():
+        pubsub = create_broadcast_stream(math.inf)
+        async with pubsub as context:
+            assert pubsub is context
+        assert pubsub._closed
+
+        pubsub = create_broadcast_stream(math.inf)
+        with pubsub as context:
+            assert pubsub is context
+        assert pubsub._closed

--- a/tests/pyutils/test_inspect.py
+++ b/tests/pyutils/test_inspect.py
@@ -137,7 +137,7 @@ def describe_inspect():
         assert inspect(test_generator) == "<generator function test_generator>"
         assert inspect(test_generator()) == "<generator test_generator>"
 
-    @mark.asyncio
+    @mark.anyio
     async def inspect_coroutine():
         async def test_coroutine():
             pass

--- a/tests/pyutils/test_is_awaitable.py
+++ b/tests/pyutils/test_is_awaitable.py
@@ -66,7 +66,7 @@ def describe_is_awaitable():
         assert not isawaitable(some_coroutine)
         assert not is_awaitable(some_coroutine)
 
-    @mark.asyncio
+    @mark.anyio
     @mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
     async def recognizes_a_coroutine_object():
         async def some_coroutine():
@@ -84,9 +84,9 @@ def describe_is_awaitable():
         assert is_awaitable(some_old_style_coroutine())
         assert is_awaitable(some_old_style_coroutine())
 
-    @mark.asyncio
+    @mark.parametrize("anyio_backend", ["asyncio"])
     @mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
-    async def recognizes_a_future_object():
+    async def recognizes_a_future_object(anyio_backend):
         async def some_coroutine():
             return False  # pragma: no cover
 
@@ -95,7 +95,7 @@ def describe_is_awaitable():
         assert is_awaitable(some_future)
         assert is_awaitable(some_future)
 
-    @mark.asyncio
+    @mark.anyio
     @mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning")
     def declines_an_async_generator():
         async def some_async_generator():

--- a/tests/pyutils/test_simple_pub_sub.py
+++ b/tests/pyutils/test_simple_pub_sub.py
@@ -1,4 +1,4 @@
-from asyncio import sleep
+from anyio import sleep
 from inspect import isawaitable
 
 from pytest import mark, raises
@@ -7,7 +7,7 @@ from graphql.pyutils import SimplePubSub
 
 
 def describe_simple_pub_sub():
-    @mark.asyncio
+    @mark.anyio
     async def subscribe_async_iterator_mock():
         pubsub = SimplePubSub()
         iterator = pubsub.get_subscriber()
@@ -51,7 +51,7 @@ def describe_simple_pub_sub():
         with raises(StopAsyncIteration):
             await iterator.__anext__()
 
-    @mark.asyncio
+    @mark.anyio
     async def iterator_aclose_empties_push_queue():
         pubsub = SimplePubSub()
         assert not pubsub.subscribers
@@ -69,7 +69,7 @@ def describe_simple_pub_sub():
         assert iterator.pull_queue.qsize() == 0
         assert not iterator.listening
 
-    @mark.asyncio
+    @mark.anyio
     async def iterator_aclose_empties_pull_queue():
         pubsub = SimplePubSub()
         assert not pubsub.subscribers
@@ -86,7 +86,7 @@ def describe_simple_pub_sub():
         assert iterator.pull_queue.qsize() == 0
         assert not iterator.listening
 
-    @mark.asyncio
+    @mark.anyio
     async def iterator_aclose_is_idempotent():
         pubsub = SimplePubSub()
         iterator = pubsub.get_subscriber()

--- a/tests/pyutils/test_simple_pub_sub.py
+++ b/tests/pyutils/test_simple_pub_sub.py
@@ -7,11 +7,12 @@ from graphql.pyutils import SimplePubSub
 
 
 def describe_simple_pub_sub():
-    @mark.anyio
-    async def subscribe_async_iterator_mock():
+    @mark.parametrize("anyio_backend", ["asyncio"])
+    async def subscribe_async_iterator_mock(anyio_backend):
         pubsub = SimplePubSub()
         iterator = pubsub.get_subscriber()
 
+        assert iterator.__aiter__() == iterator
         # Queue up publishes
         assert pubsub.emit("Apple") is True
         assert pubsub.emit("Banana") is True
@@ -51,8 +52,8 @@ def describe_simple_pub_sub():
         with raises(StopAsyncIteration):
             await iterator.__anext__()
 
-    @mark.anyio
-    async def iterator_aclose_empties_push_queue():
+    @mark.parametrize("anyio_backend", ["asyncio"])
+    async def iterator_aclose_empties_push_queue(anyio_backend):
         pubsub = SimplePubSub()
         assert not pubsub.subscribers
         iterator = pubsub.get_subscriber()
@@ -69,8 +70,8 @@ def describe_simple_pub_sub():
         assert iterator.pull_queue.qsize() == 0
         assert not iterator.listening
 
-    @mark.anyio
-    async def iterator_aclose_empties_pull_queue():
+    @mark.parametrize("anyio_backend", ["asyncio"])
+    async def iterator_aclose_empties_pull_queue(anyio_backend):
         pubsub = SimplePubSub()
         assert not pubsub.subscribers
         iterator = pubsub.get_subscriber()
@@ -86,11 +87,26 @@ def describe_simple_pub_sub():
         assert iterator.pull_queue.qsize() == 0
         assert not iterator.listening
 
-    @mark.anyio
-    async def iterator_aclose_is_idempotent():
+    @mark.parametrize("anyio_backend", ["asyncio"])
+    async def iterator_aclose_is_idempotent(anyio_backend):
         pubsub = SimplePubSub()
         iterator = pubsub.get_subscriber()
         assert iterator.listening
         for n in range(3):
             await iterator.aclose()
             assert not iterator.listening
+
+    @mark.parametrize("anyio_backend", ["asyncio"])
+    async def non_async_subscriber(anyio_backend):
+        message = "test message"
+        received_message = False
+
+        def get_msg(evt):
+            nonlocal received_message
+            assert evt == message
+            received_message = True
+
+        pubsub = SimplePubSub()
+        pubsub.subscribers.add(get_msg)
+        pubsub.emit(message)
+        assert received_message

--- a/tests/test_star_wars_query.py
+++ b/tests/test_star_wars_query.py
@@ -7,7 +7,7 @@ from .star_wars_schema import star_wars_schema as schema
 
 def describe_star_wars_query_tests():
     def describe_basic_queries():
-        @mark.asyncio
+        @mark.anyio
         async def correctly_identifies_r2_d2_as_hero_of_the_star_wars_saga():
             source = """
                 query HeroNameQuery {
@@ -19,7 +19,7 @@ def describe_star_wars_query_tests():
             result = await graphql(schema=schema, source=source)
             assert result == ({"hero": {"name": "R2-D2"}}, None)
 
-        @mark.asyncio
+        @mark.anyio
         async def accepts_positional_arguments_to_graphql():
             source = """
                 query HeroNameQuery {
@@ -34,7 +34,7 @@ def describe_star_wars_query_tests():
             sync_result = graphql_sync(schema, source)
             assert sync_result == result
 
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_query_for_the_id_and_friends_of_r2_d2():
             source = """
                 query HeroNameAndFriendsQuery {
@@ -64,7 +64,7 @@ def describe_star_wars_query_tests():
             )
 
     def describe_nested_queries():
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_query_for_the_friends_of_friends_of_r2_d2():
             source = """
                 query NestedQuery {
@@ -122,7 +122,7 @@ def describe_star_wars_query_tests():
             )
 
     def describe_using_ids_and_query_parameters_to_refetch_objects():
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_query_for_r2_d2_directly_using_his_id():
             source = """
                 query {
@@ -134,7 +134,7 @@ def describe_star_wars_query_tests():
             result = await graphql(schema=schema, source=source)
             assert result == ({"droid": {"name": "R2-D2"}}, None)
 
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_query_characters_directly_using_their_id():
             source = """
                 query FetchLukeAndC3POQuery {
@@ -152,7 +152,7 @@ def describe_star_wars_query_tests():
                 None,
             )
 
-        @mark.asyncio
+        @mark.anyio
         async def allows_creating_a_generic_query_to_fetch_luke_using_his_id():
             source = """
                 query FetchSomeIDQuery($someId: String!) {
@@ -167,7 +167,7 @@ def describe_star_wars_query_tests():
             )
             assert result == ({"human": {"name": "Luke Skywalker"}}, None)
 
-        @mark.asyncio
+        @mark.anyio
         async def allows_creating_a_generic_query_to_fetch_han_using_his_id():
             source = """
                 query FetchSomeIDQuery($someId: String!) {
@@ -182,7 +182,7 @@ def describe_star_wars_query_tests():
             )
             assert result == ({"human": {"name": "Han Solo"}}, None)
 
-        @mark.asyncio
+        @mark.anyio
         async def generic_query_that_gets_null_back_when_passed_invalid_id():
             source = """
                 query humanQuery($id: String!) {
@@ -198,7 +198,7 @@ def describe_star_wars_query_tests():
             assert result == ({"human": None}, None)
 
     def describe_using_aliases_to_change_the_key_in_the_response():
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_query_for_luke_changing_his_key_with_an_alias():
             source = """
                 query FetchLukeAliased {
@@ -210,7 +210,7 @@ def describe_star_wars_query_tests():
             result = await graphql(schema=schema, source=source)
             assert result == ({"luke": {"name": "Luke Skywalker"}}, None)
 
-        @mark.asyncio
+        @mark.anyio
         async def query_for_luke_and_leia_using_two_root_fields_and_an_alias():
             source = """
                 query FetchLukeAndLeiaAliased {
@@ -229,7 +229,7 @@ def describe_star_wars_query_tests():
             )
 
     def describe_uses_fragments_to_express_more_complex_queries():
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_query_using_duplicated_content():
             source = """
                 query DuplicateFields {
@@ -252,7 +252,7 @@ def describe_star_wars_query_tests():
                 None,
             )
 
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_use_a_fragment_to_avoid_duplicating_content():
             source = """
                 query UseFragment {
@@ -278,7 +278,7 @@ def describe_star_wars_query_tests():
             )
 
     def describe_using_typename_to_find_the_type_of_an_object():
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_verify_that_r2_d2_is_a_droid():
             source = """
                 query CheckTypeOfR2 {
@@ -291,7 +291,7 @@ def describe_star_wars_query_tests():
             result = await graphql(schema=schema, source=source)
             assert result == ({"hero": {"__typename": "Droid", "name": "R2-D2"}}, None)
 
-        @mark.asyncio
+        @mark.anyio
         async def allows_us_to_verify_that_luke_is_a_human():
             source = """
                 query CheckTypeOfLuke {
@@ -308,7 +308,7 @@ def describe_star_wars_query_tests():
             )
 
     def describe_reporting_errors_raised_in_resolvers():
-        @mark.asyncio
+        @mark.anyio
         async def correctly_reports_error_on_accessing_secret_backstory():
             source = """
                 query HeroNameQuery {
@@ -330,7 +330,7 @@ def describe_star_wars_query_tests():
                 ],
             )
 
-        @mark.asyncio
+        @mark.anyio
         async def correctly_reports_error_on_accessing_backstory_in_a_list():
             source = """
                 query HeroNameQuery {
@@ -374,7 +374,7 @@ def describe_star_wars_query_tests():
                 ],
             )
 
-        @mark.asyncio
+        @mark.anyio
         async def correctly_reports_error_on_accessing_through_an_alias():
             source = """
                 query HeroNameQuery {

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ python =
 
 [testenv:black]
 basepython = python3.9
-deps = black==22.1.0
+deps = black==22.3.0
 commands  =
     black src tests setup.py -t py39 --check
 
@@ -26,6 +26,7 @@ commands =
 basepython = python3.9
 deps =
     mypy==0.931
+    trio-typing>=0.7.0,<0.8.0
     pytest>=6.2,<7
 commands =
     mypy src tests
@@ -47,11 +48,12 @@ commands =
 [testenv]
 deps =
     pytest>=6.2,<7
-    pytest-asyncio>=0.16,<1
     pytest-benchmark>=3.4,<4
     pytest-cov>=3,<4
     pytest-describe>=2,<3
     pytest-timeout>=2,<3
+    anyio>=3.5.0
     py36,py37: typing-extensions>=4,<5
+    py37,py38,py39,py310: trio>=0.16,<0.21
 commands =
     pytest tests {posargs: --cov-report=term-missing --cov=graphql --cov=tests --cov-fail-under=100}


### PR DESCRIPTION
This PR replaces almost all asyncio usage with anyio, making graphql-core run with asyncio and trio.

This is only a proposal. It is implemented completely and tests run with asyncio and trio, but the PR also includes a few decisions that should probably be discussed before adopting the changes.

Current state:
 - tox runs successfully for python 3.7, 3.8, 3.9, and 3.10 (python 3.6 is currently broken on my machine, cannot run the tests with it)
 - every async test is run in asyncio and in trio
 - performance of the existing async benchmark seems to be unaffected when using the asyncio event loop (see benchmarks below) 

The following changes were necessary to use anyio:
 - minium python version had to be increased from 3.6.0 to 3.6.2
 - replacing asyncio functions with their anyio counterpart (e.g. asyncio.sleep -> anyio.sleep)
 - all create_task / ensure_future calls are forbidden in anyio. These code parts were rewritten using anyio task groups.

The following decisions should probably be discussed:
 - exception groups are caught and only the first exception is raised. 
 - SimplePubSub / SimplePubSubIterator are unchanged, adapting them to anyio would change their API too much. MemoryObjectBroadcastStream was added to take its place. 
 
ToDo:
 - documentation probably needs to be updated (I did not change anything)
 - run tests & fix issues for python 3.6

I am aware that this is a large change and it comes with (small) downsides, 
e.g. a minimum python version of 3.6.2 and some extra effort for the users of SimplePubSub.
But it would allow the use of graphql with the trio event loop. 
Having spent countless hours debugging due to some asyncio task that did not close correctly, I would
be extremely happy to have a structured concurrency approach available for graphql.

If you are at all interested in this proposal, please let me know.


<details>
  <summary>Benchmarks before changes:</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.7.13, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=5 calibration_precision=10 warmup=True warmup_iterations=100000)
rootdir: /home/stefan/ws/graphql-core, configfile: setup.cfg
plugins: benchmark-3.4.1, cov-3.0.0, asyncio-0.16.0, anyio-3.5.0, timeout-2.1.0, describe-2.0.1
timeout: 100.0s
timeout method: signal
timeout func_only: False
collected 2370 items / 2359 deselected / 11 selected

tests/benchmarks/test_build_ast_schema.py .                              [  9%]
tests/benchmarks/test_build_client_schema.py .                           [ 18%]
tests/benchmarks/test_execution_async.py .                               [ 27%]
tests/benchmarks/test_execution_sync.py .                                [ 36%]
tests/benchmarks/test_introspection_from_schema.py .                     [ 45%]
tests/benchmarks/test_parser.py .                                        [ 54%]
tests/benchmarks/test_validate_gql.py .                                  [ 63%]
tests/benchmarks/test_validate_invalid_gql.py .                          [ 72%]
tests/benchmarks/test_validate_sdl.py .                                  [ 81%]
tests/benchmarks/test_visit.py ..                                        [100%]


--------------------------------------------------------------------------------------------------------- benchmark: 11 tests ----------------------------------------------------------------------------------------------------------
Name (time in us)                                 Min                     Max                    Mean                 StdDev                  Median                   IQR            Outliers         OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_execute_basic_sync                      679.1020 (1.0)       24,167.3440 (1.08)         795.1533 (1.0)         615.8840 (1.92)         778.2310 (1.0)        110.2390 (1.54)      157;381  1,257.6191 (1.0)        7358           1
test_execute_basic_async                     764.3180 (1.13)      24,417.7180 (1.09)         880.1823 (1.11)        648.0944 (2.02)         832.9540 (1.07)       114.0020 (1.59)       65;265  1,136.1283 (0.90)       6536           1
test_parse_kitchen_sink                    1,361.3850 (2.00)      22,441.8060 (1.0)        1,461.0742 (1.84)        677.6062 (2.11)       1,435.4575 (1.84)        71.7050 (1.0)         4;199    684.4280 (0.54)       3680           1
test_validate_introspection_query          4,038.9070 (5.95)      48,622.5970 (2.17)       4,381.5331 (5.51)      1,802.7149 (5.62)       4,194.7020 (5.39)       111.0915 (1.55)        2;122    228.2306 (0.18)       1241           1
test_validate_invalid_query               37,922.6710 (55.84)     40,026.3080 (1.78)      38,436.2805 (48.34)       365.8637 (1.14)      38,341.9050 (49.27)      330.5452 (4.61)         17;9     26.0171 (0.02)        131           1
test_build_schema_from_ast                40,436.8810 (59.54)     91,369.1450 (4.07)      52,498.9107 (66.02)    19,934.7782 (62.14)     41,902.6470 (53.84)    1,569.7452 (21.89)       29;29     19.0480 (0.02)        123           1
test_build_schema_from_introspection      46,932.1740 (69.11)     87,449.3990 (3.90)      56,032.1161 (70.47)    15,406.7749 (48.02)     47,648.6120 (61.23)    1,379.6577 (19.24)       25;25     17.8469 (0.01)        107           1
test_visit_all_ast_nodes                  57,287.9200 (84.36)     58,812.3470 (2.62)      57,831.8654 (72.73)       320.8184 (1.0)       57,809.7725 (74.28)      468.2680 (6.53)         29;1     17.2915 (0.01)         88           1
test_validate_sdl_document               116,616.9430 (171.72)   119,051.0130 (5.30)     117,596.4405 (147.89)      634.0356 (1.98)     117,494.7540 (150.98)     847.3555 (11.82)        13;0      8.5037 (0.01)         43           1
test_execute_introspection_query         215,637.0560 (317.53)   254,215.4660 (11.33)    222,730.8371 (280.11)   13,984.2738 (43.59)    216,851.9790 (278.65)     877.4840 (12.24)         4;4      4.4897 (0.00)         24           1
test_visit_all_ast_nodes_in_parallel     611,041.8340 (899.78)   617,905.6140 (27.53)    614,241.2548 (772.48)    2,416.0767 (7.53)     613,784.0130 (788.69)   3,670.1400 (51.18)         3;0      1.6280 (0.00)          9           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
=============== 11 passed, 2359 deselected in 184.28s (0:03:04) ================
```
</details>

<details>
  <summary>Benchmarks after changes:</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.7.13, pytest-6.2.5, py-1.11.0, pluggy-1.0.0
benchmark: 3.4.1 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=5 calibration_precision=10 warmup=True warmup_iterations=100000)
rootdir: /home/stefan/ws/graphql-core, configfile: setup.cfg
plugins: benchmark-3.4.1, cov-3.0.0, anyio-3.5.0, timeout-2.1.0, describe-2.0.1
timeout: 100.0s
timeout method: signal
timeout func_only: False
collected 2516 items / 2504 deselected / 12 selected

tests/benchmarks/test_build_ast_schema.py .                              [  8%]
tests/benchmarks/test_build_client_schema.py .                           [ 16%]
tests/benchmarks/test_execution_async.py ..                              [ 33%]
tests/benchmarks/test_execution_sync.py .                                [ 41%]
tests/benchmarks/test_introspection_from_schema.py .                     [ 50%]
tests/benchmarks/test_parser.py .                                        [ 58%]
tests/benchmarks/test_validate_gql.py .                                  [ 66%]
tests/benchmarks/test_validate_invalid_gql.py .                          [ 75%]
tests/benchmarks/test_validate_sdl.py .                                  [ 83%]
tests/benchmarks/test_visit.py ..                                        [100%]


--------------------------------------------------------------------------------------------------------- benchmark: 12 tests ----------------------------------------------------------------------------------------------------------
Name (time in us)                                 Min                     Max                    Mean                 StdDev                  Median                   IQR            Outliers         OPS            Rounds  Iterations
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_execute_basic_sync                      661.9170 (1.0)       25,781.1220 (1.29)         763.7950 (1.0)         647.2897 (2.59)         727.1705 (1.0)         99.9350 (1.60)       10;310  1,309.2518 (1.0)        7574           1
test_execute_basic_async[asyncio]            789.3590 (1.19)      20,032.9120 (1.0)          867.8673 (1.14)        249.4849 (1.0)          906.9380 (1.25)       120.7202 (1.93)          6;8  1,152.2499 (0.88)       6343           1
test_execute_basic_async_trio[trio]        1,251.8120 (1.89)      25,944.9790 (1.30)       1,409.2772 (1.85)        680.1598 (2.73)       1,395.3320 (1.92)       129.8407 (2.08)        3;228    709.5836 (0.54)       4013           1
test_parse_kitchen_sink                    1,330.0340 (2.01)      23,528.3300 (1.17)       1,424.0817 (1.86)        723.1457 (2.90)       1,402.3740 (1.93)        62.5005 (1.0)         4;185    702.2069 (0.54)       3772           1
test_validate_introspection_query          3,918.3780 (5.92)      47,985.1300 (2.40)       4,178.4954 (5.47)      1,758.7993 (7.05)       4,011.1160 (5.52)        78.7470 (1.26)        2;129    239.3206 (0.18)       1277           1
test_validate_invalid_query               37,027.1740 (55.94)     38,657.1470 (1.93)      37,451.0217 (49.03)       271.5596 (1.09)      37,385.6900 (51.41)      283.0698 (4.53)         30;8     26.7015 (0.02)        135           1
test_build_schema_from_ast                38,402.0660 (58.02)     87,811.6550 (4.38)      50,244.0027 (65.78)    19,427.7732 (77.87)     39,887.3900 (54.85)    1,784.4250 (28.55)       31;31     19.9029 (0.02)        130           1
test_build_schema_from_introspection      44,885.4960 (67.81)     83,229.9070 (4.15)      53,670.0072 (70.27)    14,769.6549 (59.20)     45,680.3725 (62.82)    1,343.1600 (21.49)       26;26     18.6324 (0.01)        112           1
test_visit_all_ast_nodes                  55,416.7260 (83.72)     56,546.7950 (2.82)      55,881.9364 (73.16)       251.1629 (1.01)      55,881.2460 (76.85)      382.7483 (6.12)         31;0     17.8949 (0.01)         91           1
test_validate_sdl_document               112,529.1490 (170.00)   152,931.9640 (7.63)     114,881.9283 (150.41)    5,848.5372 (23.44)    113,915.4470 (156.66)   1,022.5075 (16.36)         1;2      8.7046 (0.01)         45           1
test_execute_introspection_query         210,025.7760 (317.30)   248,757.4280 (12.42)    216,474.8744 (283.42)   12,211.5627 (48.95)    212,063.4750 (291.63)   2,000.2005 (32.00)         3;3      4.6195 (0.00)         24           1
test_visit_all_ast_nodes_in_parallel     610,209.5660 (921.88)   614,215.2950 (30.66)    612,014.3380 (801.28)    1,352.9536 (5.42)     611,614.2970 (841.09)   1,486.0685 (23.78)         3;0      1.6339 (0.00)          9           1
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
=============== 12 passed, 2504 deselected in 199.34s (0:03:19) ================
```
</details>