### PR TITLE
when passing vars to an attribute with multiple args make sure `parse_literal` consumes at least 2 params

### DIFF
--- a/src/graphql/utilities/value_from_ast.py
+++ b/src/graphql/utilities/value_from_ast.py
@@ -1,3 +1,4 @@
+import inspect as inspect_builtin
 from typing import Any, Dict, List, Optional, cast
 
 from ..language import (
@@ -128,7 +129,10 @@ def value_from_ast(
         type_ = cast(GraphQLScalarType, type_)
         # noinspection PyBroadException
         try:
-            if variables:
+            if (
+                variables
+                and len(inspect_builtin.signature(type_.parse_literal).parameters) >= 2
+            ):
                 result = type_.parse_literal(value_node, variables)
             else:
                 result = type_.parse_literal(value_node)


### PR DESCRIPTION
Problem:
This PR addresses the problem I encountered when querying with filter-variables with a list of filter arguments
of which at least one value is a scalar type that does not interpolate any variable. At the `parse_literal()` call site
the test for existence of `variables` is misleading resulting in a false return of `Undefined` because of a mismatch
of `parse_literal()` signatures of different types, some taking `variables` as a second parameter, some not (e. g. `graphene.types.generic.GenericScalar` . In any case the presence of variables is not a sufficient criteria.

Solution:
`variables` may be passed to a scalar type that does not do anything with them. We assume that the scalar is still a valid case that should not evaluate to `Undefined`. In order to disregard the passed `variables` we check for the implemented `parse_literal()` method to actually consume a second parameter.

Example case: evaluation of a `GraphQLList` type that recurringly invokes `parse_literal`
passing the same `variables` regardless of whether the variables passed actually
are relevant for the scalar currently evaluated.