### PR TITLE
Bugfix: Cast error message to string to handle proxy objects

### DIFF
--- a/src/graphql/error/located_error.py
+++ b/src/graphql/error/located_error.py
@@ -29,7 +29,7 @@ def located_error(
         return original_error
     try:
         # noinspection PyUnresolvedReferences
-        message = original_error.message  # type: ignore
+        message = str(original_error.message)  # type: ignore
     except AttributeError:
         message = str(original_error)
     try:

--- a/tests/error/test_located_error.py
+++ b/tests/error/test_located_error.py
@@ -2,6 +2,8 @@ from typing import cast, Any
 
 from graphql.error import GraphQLError, located_error
 
+from ..utils import dedent
+
 
 def describe_located_error():
     def throws_without_an_original_error():
@@ -23,3 +25,24 @@ def describe_located_error():
         e = Exception("I am from elasticsearch")
         cast(Any, e).path = "/something/feed/_search"
         assert located_error(e, [], []) is not e
+
+    def handles_proxy_error_messages():
+        class ProxyString:
+            def __init__(self, value):
+                self.value = value
+
+            def __str__(self):
+                return self.value
+
+        class MyError(Exception):
+            def __init__(self):
+                self.message = ProxyString("Example error")
+                super().__init__()
+
+        error = located_error(MyError(), [], [])
+
+        assert str(error) == dedent(
+            """
+            Example error
+            """
+        )


### PR DESCRIPTION
Some frameworks (Django as an example) use a lazy evaluated object to represent error messages (https://github.com/django/django/blob/49b470b9187b6be60e573fed08c8f4a87f133750/django/utils/functional.py#L87-L96). This breaks graphql-core when it tries to format the error as a string. 

This PR fixes this bug by forcing the error message to a string when creating a GraphQLError object.