### PR TITLE
Fix poetry installation (newline in description)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "graphql-core"
 version = "3.2.1"
 description = """
-GraphQL-core is a Python port of GraphQL.js,
+GraphQL-core is a Python port of GraphQL.js,\
  the JavaScript reference implementation for GraphQL."""
 license = "MIT"
 authors = [


### PR DESCRIPTION
```
$ poetry install .

The Poetry configuration is invalid:
  - [description] 'GraphQL-core is a Python port of GraphQL.js,\n the JavaScript reference implementation for GraphQL.' does not match '^[^\n]*$'
```

~fixes~ relates to #178
relates to https://github.com/Homebrew/homebrew-core/pull/109642