### PR TITLE
sort enums by name when printing schema

### DIFF
--- a/src/graphql/utilities/print_schema.py
+++ b/src/graphql/utilities/print_schema.py
@@ -180,7 +180,7 @@ def print_enum(type_: GraphQLEnumType) -> str:
         print_description(value, "  ", not i)
         + f"  {name}"
         + print_deprecated(value.deprecation_reason)
-        for i, (name, value) in enumerate(type_.values.items())
+        for i, (name, value) in enumerate(sorted(type_.values.items(), key=lambda x: x[0]))
     ]
     return print_description(type_) + f"enum {type_.name}" + print_block(values)
 


### PR DESCRIPTION
We run the following to generate a schema file, but the enums are not printed in a reliable order. This creates unnecessary code diffs.

```py
from graphql.utils import schema_printer
from .gql import schema

schema_str = schema_printer.print_schema(schema)
fp = open("gql/schema.graphql", "w")
fp.write(schema_str)
fp.close()
```

This PR attempts to solve this by sorting the enum types by name before printing.