### PR TITLE
Simplify MapAsyncIterable using async generator semantics

### DIFF
--- a/src/graphql/execution/map_async_iterable.py
+++ b/src/graphql/execution/map_async_iterable.py
@@ -23,7 +23,7 @@ class MapAsyncIterable:
     """
 
     def __init__(self, iterable: AsyncIterable, callback: Callable) -> None:
-        self.iterable = iterable
+        self.iterator = iterable.__aiter__()
         self.callback = callback
         self._ageniter = self._agen()
         self.is_closed = False  # used by unittests
@@ -38,13 +38,13 @@ class MapAsyncIterable:
 
     async def _agen(self) -> Any:
         try:
-            async for v in self.iterable:
+            async for v in self.iterator:
                 result = self.callback(v)
                 yield (await result) if isawaitable(result) else result
         finally:
             self.is_closed = True
-            if hasattr(self.iterable, "aclose"):
-                await self.iterable.aclose()
+            if hasattr(self.iterator, "aclose"):
+                await self.iterator.aclose()
 
     # This is not a standard method and is only used in unittests.  Should be removed.
     async def athrow(

--- a/tests/execution/test_map_async_iterable.py
+++ b/tests/execution/test_map_async_iterable.py
@@ -18,6 +18,14 @@ except NameError:  # pragma: no cover (Python < 3.10)
         return await iterator.__anext__()
 
 
+async def map_single(x):
+    return x
+
+
+async def map_doubles(x):
+    return x + x
+
+
 def describe_map_async_iterable():
     @mark.asyncio
     async def maps_over_async_generator():
@@ -26,7 +34,7 @@ def describe_map_async_iterable():
             yield 2
             yield 3
 
-        doubles = MapAsyncIterable(source(), lambda x: x + x)
+        doubles = MapAsyncIterable(source(), map_doubles)
 
         assert await anext(doubles) == 2
         assert await anext(doubles) == 4
@@ -48,7 +56,7 @@ def describe_map_async_iterable():
                 except IndexError:
                     raise StopAsyncIteration
 
-        doubles = MapAsyncIterable(Iterable(), lambda x: x + x)
+        doubles = MapAsyncIterable(Iterable(), map_doubles)
 
         values = [value async for value in doubles]
 
@@ -62,7 +70,7 @@ def describe_map_async_iterable():
             yield 2
             yield 3
 
-        doubles = MapAsyncIterable(source(), lambda x: x + x)
+        doubles = MapAsyncIterable(source(), map_doubles)
 
         values = [value async for value in doubles]
 
@@ -91,7 +99,7 @@ def describe_map_async_iterable():
             yield 2
             yield 3  # pragma: no cover
 
-        doubles = MapAsyncIterable(source(), lambda x: x + x)
+        doubles = MapAsyncIterable(source(), map_doubles)
 
         assert await anext(doubles) == 2
         assert await anext(doubles) == 4
@@ -119,7 +127,7 @@ def describe_map_async_iterable():
                 except IndexError:  # pragma: no cover
                     raise StopAsyncIteration
 
-        doubles = MapAsyncIterable(Iterable(), lambda x: x + x)
+        doubles = MapAsyncIterable(Iterable(), map_doubles)
 
         assert await anext(doubles) == 2
         assert await anext(doubles) == 4
@@ -145,7 +153,7 @@ def describe_map_async_iterable():
                 yield "Done"
                 yield "Last"  # pragma: no cover
 
-        doubles = MapAsyncIterable(source(), lambda x: x + x)
+        doubles = MapAsyncIterable(source(), map_doubles)
 
         assert await anext(doubles) == 2
         assert await anext(doubles) == 4
@@ -168,7 +176,7 @@ def describe_map_async_iterable():
                 except IndexError:  # pragma: no cover
                     raise StopAsyncIteration
 
-        doubles = MapAsyncIterable(Iterable(), lambda x: x + x)
+        doubles = MapAsyncIterable(Iterable(), map_doubles)
 
         assert await anext(doubles) == 2
         assert await anext(doubles) == 4
@@ -194,7 +202,7 @@ def describe_map_async_iterable():
             async def __anext__(self):
                 return 1
 
-        one = MapAsyncIterable(Iterable(), lambda x: x)
+        one = MapAsyncIterable(Iterable(), map_single)
 
         assert await anext(one) == 1
 
@@ -220,7 +228,7 @@ def describe_map_async_iterable():
             async def __anext__(self):
                 return 1
 
-        one = MapAsyncIterable(Iterable(), lambda x: x)
+        one = MapAsyncIterable(Iterable(), map_single)
 
         assert await anext(one) == 1
 
@@ -247,7 +255,7 @@ def describe_map_async_iterable():
             except Exception as e:
                 yield e
 
-        doubles = MapAsyncIterable(source(), lambda x: x + x)
+        doubles = MapAsyncIterable(source(), map_doubles)
 
         assert await anext(doubles) == 2
         assert await anext(doubles) == 4
@@ -262,7 +270,7 @@ def describe_map_async_iterable():
             yield "Hello"
             raise RuntimeError("Goodbye")
 
-        doubles = MapAsyncIterable(source(), lambda x: x + x)
+        doubles = MapAsyncIterable(source(), map_doubles)
 
         assert await anext(doubles) == "HelloHello"
 
@@ -276,7 +284,7 @@ def describe_map_async_iterable():
         async def source():
             yield "Hello"
 
-        doubles = MapAsyncIterable(source(), lambda x: x + x)
+        doubles = MapAsyncIterable(source(), map_doubles)
 
         assert await anext(doubles) == "HelloHello"
 
@@ -305,7 +313,7 @@ def describe_map_async_iterable():
                     raise StopAsyncIteration
                 return self.counter
 
-        def double(x):
+        async def double(x):
             return x + x
 
         for iterable in source, Source:
@@ -377,7 +385,11 @@ def describe_map_async_iterable():
             yield 3  # pragma: no cover
 
         singles = source()
-        doubles = MapAsyncIterable(singles, lambda x: x * 2)
+
+        async def double(x):
+            return x * 2
+
+        doubles = MapAsyncIterable(singles, double)
 
         result = await anext(doubles)
         assert result == 2
@@ -431,7 +443,7 @@ def describe_map_async_iterable():
                 self.is_closed = True
 
         iterable = Iterable()
-        doubles = MapAsyncIterable(iterable, lambda x: x + x)  # pragma: no cover exit
+        doubles = MapAsyncIterable(iterable, map_doubles)  # pragma: no cover exit
         cancelled = False
 
         async def iterator_task():


### PR DESCRIPTION
This PR rewrites the `MapAsyncIteable` using simple native async primitives

## Problem

The existing implementation of `MapAsyncIterable` has several problems, mostly to do with `aclose()` semantics.
This has become evident in projects such as [Strawberry-graphql](https://github.com/strawberry-graphql/strawberry)
where calling `aclose()` on a subscription sometimes behaves in unexpected manner.  Fundamentally this is caused by the unnecessarily complex implementation, containing inner `Task` objects (created by `ensure_future()`) created for each iterated value.

A concrete problem which sometimes manifests itself is that calling `aclose()` on this iterator results in a RuntimeError.  The reason is that the actual `__anext()__` call is currently performed in a separate `Task`.  Even when that task is cancelled it may still be pending

The iterable _tries_ to look like an `AsyncGenerator` but fails to correctly implement the changes of `aclose()` which
added in Python 3.8, where such an iterator is not allowed to be re-entrant.

Ultimately, the class-based implementation is unnecessarily complex for something as fundamentally simple as iterating over, and mapping, another iterable.

## Changes

This PR rewrites this iterator using an AsyncGenerator, thus ensuring that simple and understandable internal mechanisms
are used.  It avoids any use of synchronization primitives and Task objects and simply iterates over the results.  It provides the extended `aclose()` optional semantics for the inner iterable as expected.

We remove unnecessary unit tests for this class and fix the ones making strange assumptions, such as ones making it allowable to ignore GeneratorExits and _yield_ data.  Also a test for un-closing an iterator is removed, since that is a completely un-pythonic idea.

## Further improvements

Further enhancements might be:

- remove the `athrow()` and `is_closed` members which serve no purpose
- implement this method entirely as an Async Generator, and drop the special type, which only complicates code.  The relevant checks in graphql-core could then use the `inspect.isasyncgen()` method instead.


