### PR TITLE
Fix `IntrospectionQuery` type definition

### DIFF
--- a/src/graphql/utilities/get_introspection_query.py
+++ b/src/graphql/utilities/get_introspection_query.py
@@ -302,7 +302,5 @@ class IntrospectionSchema(MaybeWithDescription):
     directives: list[IntrospectionDirective]
 
 
-class IntrospectionQuery(TypedDict):
-    """The root typed dictionary for schema introspections."""
-
-    __schema: IntrospectionSchema
+# The root typed dictionary for schema introspections.
+IntrospectionQuery = TypedDict("IntrospectionQuery", [("__schema", IntrospectionSchema)])

--- a/src/graphql/utilities/get_introspection_query.py
+++ b/src/graphql/utilities/get_introspection_query.py
@@ -303,4 +303,4 @@ class IntrospectionSchema(MaybeWithDescription):
 
 
 # The root typed dictionary for schema introspections.
-IntrospectionQuery = TypedDict("IntrospectionQuery", [("__schema", IntrospectionSchema)])
+IntrospectionQuery = TypedDict("IntrospectionQuery", {"__schema": IntrospectionSchema})

--- a/src/graphql/utilities/get_introspection_query.py
+++ b/src/graphql/utilities/get_introspection_query.py
@@ -303,4 +303,7 @@ class IntrospectionSchema(MaybeWithDescription):
 
 
 # The root typed dictionary for schema introspections.
-IntrospectionQuery = TypedDict("IntrospectionQuery", {"__schema": IntrospectionSchema})
+IntrospectionQuery = TypedDict(  # noqa: UP013
+    "IntrospectionQuery",
+    {"__schema": IntrospectionSchema},
+)


### PR DESCRIPTION
`TypedDict` mangles private names as regular Python classes do. So, `__schema` name will become `_IntrospectionQuery__schema` instead. But, inline definition will preserve a correct name for the field. See https://github.com/python/cpython/issues/129567

Found during https://github.com/python/mypy/pull/16715