### PR TITLE
Fix AttributeError on exception with field `source`

### DIFF
--- a/src/graphql/error/located_error.py
+++ b/src/graphql/error/located_error.py
@@ -6,6 +6,7 @@ from contextlib import suppress
 from typing import TYPE_CHECKING, Collection
 
 from ..pyutils import inspect
+from ..language.source import is_source, Source
 from .graphql_error import GraphQLError
 
 if TYPE_CHECKING:
@@ -39,7 +40,9 @@ def located_error(
     except AttributeError:
         message = str(original_error)
     try:
-        source = original_error.source  # type: ignore
+        source = original_error.source
+        if not is_source(source):
+            source = Source(source) if isinstance(source, str) else None
     except AttributeError:
         source = None
     try:

--- a/tests/error/test_located_error.py
+++ b/tests/error/test_located_error.py
@@ -35,3 +35,11 @@ def describe_located_error():
                 super().__init__()
 
         assert str(located_error(LazyError())) == "lazy"
+
+    def handles_error_with_str_source():
+        class CustomException(Exception):
+            def __init__(self, message, source):
+                super().__init__(message)
+                self.source = source
+        e = located_error(CustomException("msg", "source"))
+        assert e.source and e.source.get_location(0)


### PR DESCRIPTION
trying to fix below error, which happens if the handler raises an custom exception with `source` field inside

```
            locations: list[SourceLocation] | None = [
>               source.get_location(pos) for pos in positions
                ^^^^^^^^^^^^^^^^^^^
            ]
E           AttributeError: 'str' object has no attribute 'get_location'

.tox/py312/lib/python3.12/site-packages/graphql/error/graphql_error.py:161: AttributeError
```
