### PR TITLE
feat: show `@oneOf` in introspection query

### DIFF
--- a/src/graphql/utilities/build_client_schema.py
+++ b/src/graphql/utilities/build_client_schema.py
@@ -256,7 +256,7 @@ def build_client_schema(
             fields=lambda: build_input_value_def_map(
                 input_object_introspection["inputFields"]
             ),
-            is_one_of= input_object_introspection.get("isOneOf"),
+            is_one_of=input_object_introspection.get("isOneOf"),
         )
 
     type_builders: dict[str, Callable[[IntrospectionType], GraphQLNamedType]] = {

--- a/src/graphql/utilities/build_client_schema.py
+++ b/src/graphql/utilities/build_client_schema.py
@@ -256,6 +256,7 @@ def build_client_schema(
             fields=lambda: build_input_value_def_map(
                 input_object_introspection["inputFields"]
             ),
+            is_one_of= input_object_introspection.get("isOneOf"),
         )
 
     type_builders: dict[str, Callable[[IntrospectionType], GraphQLNamedType]] = {

--- a/src/graphql/utilities/get_introspection_query.py
+++ b/src/graphql/utilities/get_introspection_query.py
@@ -55,7 +55,7 @@ def get_introspection_query(
     maybe_specified_by_url = "specifiedByURL" if specified_by_url else ""
     maybe_directive_is_repeatable = "isRepeatable" if directive_is_repeatable else ""
     maybe_schema_description = maybe_description if schema_description else ""
-    maybe_input_object_one_of = 'isOneOf' if input_object_one_of else  "";
+    maybe_input_object_one_of = "isOneOf" if input_object_one_of else ""
 
     def input_deprecation(string: str) -> str | None:
         return string if input_value_deprecation else ""

--- a/src/graphql/utilities/get_introspection_query.py
+++ b/src/graphql/utilities/get_introspection_query.py
@@ -17,7 +17,6 @@ try:
 except ImportError:  # Python < 3.10
     from typing_extensions import TypeAlias
 
-
 __all__ = [
     "IntrospectionDirective",
     "IntrospectionEnumType",
@@ -44,6 +43,7 @@ def get_introspection_query(
     directive_is_repeatable: bool = False,
     schema_description: bool = False,
     input_value_deprecation: bool = False,
+    input_object_one_of: bool = False,
 ) -> str:
     """Get a query for introspection.
 
@@ -55,6 +55,7 @@ def get_introspection_query(
     maybe_specified_by_url = "specifiedByURL" if specified_by_url else ""
     maybe_directive_is_repeatable = "isRepeatable" if directive_is_repeatable else ""
     maybe_schema_description = maybe_description if schema_description else ""
+    maybe_input_object_one_of = 'isOneOf' if input_object_one_of else  "";
 
     def input_deprecation(string: str) -> str | None:
         return string if input_value_deprecation else ""
@@ -87,6 +88,7 @@ def get_introspection_query(
           name
           {maybe_description}
           {maybe_specified_by_url}
+          {maybe_input_object_one_of}
           fields(includeDeprecated: true) {{
             name
             {maybe_description}
@@ -253,6 +255,7 @@ class IntrospectionEnumType(WithName):
 class IntrospectionInputObjectType(WithName):
     kind: Literal["input_object"]
     inputFields: list[IntrospectionInputValue]
+    isOneOf: bool
 
 
 IntrospectionType: TypeAlias = Union[
@@ -264,7 +267,6 @@ IntrospectionType: TypeAlias = Union[
     IntrospectionInputObjectType,
 ]
 
-
 IntrospectionOutputType: TypeAlias = Union[
     IntrospectionScalarType,
     IntrospectionObjectType,
@@ -272,7 +274,6 @@ IntrospectionOutputType: TypeAlias = Union[
     IntrospectionUnionType,
     IntrospectionEnumType,
 ]
-
 
 IntrospectionInputType: TypeAlias = Union[
     IntrospectionScalarType, IntrospectionEnumType, IntrospectionInputObjectType

--- a/src/graphql/utilities/introspection_from_schema.py
+++ b/src/graphql/utilities/introspection_from_schema.py
@@ -21,6 +21,7 @@ def introspection_from_schema(
     directive_is_repeatable: bool = True,
     schema_description: bool = True,
     input_value_deprecation: bool = True,
+    input_object_one_of: bool = True,
 ) -> IntrospectionQuery:
     """Build an IntrospectionQuery from a GraphQLSchema
 
@@ -37,6 +38,7 @@ def introspection_from_schema(
             directive_is_repeatable,
             schema_description,
             input_value_deprecation,
+            input_object_one_of,
         )
     )
 

--- a/tests/utilities/test_get_introspection_query.py
+++ b/tests/utilities/test_get_introspection_query.py
@@ -2,9 +2,6 @@ from __future__ import annotations
 
 import re
 from typing import Pattern
-
-from wheel.macosx_libfile import version_min_command_fields
-
 from graphql.language import parse
 from graphql.utilities import build_schema, get_introspection_query
 from graphql.validation import validate

--- a/tests/utilities/test_get_introspection_query.py
+++ b/tests/utilities/test_get_introspection_query.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import re
 from typing import Pattern
 
+from wheel.macosx_libfile import version_min_command_fields
+
 from graphql.language import parse
 from graphql.utilities import build_schema, get_introspection_query
 from graphql.validation import validate
@@ -79,6 +81,11 @@ def describe_get_introspection_query():
         ExcpectIntrospectionQuery(input_value_deprecation=False).to_match(
             "deprecationReason", 2
         )
+
+    def includes_input_object_one_of_field():
+        ExcpectIntrospectionQuery().to_not_match("isOneOf")
+        ExcpectIntrospectionQuery(input_object_one_of=True).to_match("isOneOf")
+        ExcpectIntrospectionQuery(input_object_one_of=False).to_not_match("isOneOf")
 
     def includes_deprecated_input_field_and_args():
         ExcpectIntrospectionQuery().to_match("includeDeprecated: true", 2)


### PR DESCRIPTION
This PR ports https://github.com/graphql/graphql-js/pull/4078 to python to ease the adoption of the new `oneOf` directive freshly contained in the new spec release. As requested by strawberry issue https://github.com/strawberry-graphql/strawberry/issues/3975

I left out the tests to `src/utilities/__tests__/buildClientSchema-test.ts`, as I couldn't find a matching file containing all relevant tests. Feel free to let me know if you desire any changes 😊 