### PR TITLE
fix: don't loose extensions of enum values when sorting schemas

### DIFF
--- a/src/graphql/utilities/lexicographic_sort_schema.py
+++ b/src/graphql/utilities/lexicographic_sort_schema.py
@@ -146,6 +146,7 @@ def lexicographic_sort_schema(schema: GraphQLSchema) -> GraphQLSchema:
                             val.value,
                             description=val.description,
                             deprecation_reason=val.deprecation_reason,
+                            extensions=val.extensions,
                             ast_node=val.ast_node,
                         )
                         for name, val in sorted(type_.values.items())


### PR DESCRIPTION
When sorting a schema lexicographically, the enum values lost their extensions.