### PR TITLE
RFC: Adopt msgspec.Structs for 5X parse performance and unlock 25X faster query caching deserialization

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.9', 'pypy3.10', 'pypy3.11']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14', 'pypy3.10', 'pypy3.11']
 
     steps:
       - name: Checkout project
@@ -37,44 +37,3 @@ jobs:
       - name: Run unit tests with tox
         id: test
         run: tox
-
-  tests-old:
-    name: 🧪 Tests (older Python versions)
-    runs-on: ubuntu-22.04
-
-    strategy:
-      matrix:
-        python-version: ['3.7', '3.8']
-
-    steps:
-      - name: Checkout project
-        id: checkout
-        uses: actions/checkout@v5
-
-      - name: Set up Python 3.14 (tox runner)
-        id: setup-python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
-      - name: Install uv
-        id: setup-uv
-        uses: astral-sh/setup-uv@v6
-
-      - name: Install tox and plugins
-        id: install-tox
-        run: |
-          uv pip install --system tox tox-uv tox-gh-actions
-
-      - name: Set up target Python ${{ matrix.python-version }}
-        id: setup-target-python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Run unit tests with tox for target
-        id: test
-        shell: bash
-        run: |
-          ENV="py${{ matrix.python-version }}"; ENV=${ENV/./}
-          python3.14 -m tox -e "$ENV"

--- a/docs/usage/parser.rst
+++ b/docs/usage/parser.rst
@@ -35,30 +35,30 @@ This will give the same result as manually creating the AST document::
 
     from graphql.language.ast import *
 
-    document = DocumentNode(definitions=[
+    document = DocumentNode(definitions=(
         ObjectTypeDefinitionNode(
             name=NameNode(value='Query'),
-            fields=[
+            fields=(
                 FieldDefinitionNode(
                     name=NameNode(value='me'),
                     type=NamedTypeNode(name=NameNode(value='User')),
-                    arguments=[], directives=[])
-                ], directives=[], interfaces=[]),
+                    arguments=(), directives=()),
+                ), interfaces=(), directives=()),
         ObjectTypeDefinitionNode(
             name=NameNode(value='User'),
-            fields=[
+            fields=(
                 FieldDefinitionNode(
                     name=NameNode(value='id'),
                     type=NamedTypeNode(
                         name=NameNode(value='ID')),
-                    arguments=[], directives=[]),
+                    arguments=(), directives=()),
                 FieldDefinitionNode(
                     name=NameNode(value='name'),
                     type=NamedTypeNode(
                         name=NameNode(value='String')),
-                    arguments=[], directives=[]),
-                ], directives=[], interfaces=[]),
-        ])
+                    arguments=(), directives=()),
+                ), interfaces=(), directives=()),
+        ))
 
 
 When parsing with ``no_location=False`` (the default), the AST nodes will also have a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,9 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = []
+dependencies = [
+    "msgspec>=0.19",
+]
 
 [project.urls]
 Homepage = "https://github.com/graphql-python/graphql-core"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "graphql-core"
 version = "3.3.0a11"
 description = "GraphQL-core is a Python port of GraphQL.js, the JavaScript reference implementation for GraphQL."
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [ { name = "Christoph Zwerschke", email = "cito@online.de" } ]
@@ -13,19 +13,13 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-dependencies = [
-    "typing-extensions>=4.12.2,<5; python_version >= '3.8' and python_version < '3.10'",
-    "typing-extensions>=4.7.1,<5; python_version < '3.8'",
-]
+dependencies = []
 
 [project.urls]
 Homepage = "https://github.com/graphql-python/graphql-core"
@@ -35,36 +29,22 @@ Changelog = "https://github.com/graphql-python/graphql-core/releases"
 
 [dependency-groups]
 test = [
-    "anyio>=4.6; python_version>='3.9'",
-    "anyio>=3.7; python_version<'3.9'",
-    "pytest>=8.4; python_version>='3.9'",
-    "pytest>=8.3; python_version>='3.8' and python_version<'3.9'",
-    "pytest>=7.4,<8; python_version<'3.8'",
-    "pytest-benchmark>=5.2; python_version>='3.9'",
-    "pytest-benchmark>=4.0,<5; python_version<'3.9'",
-    "pytest-cov>=6.0; python_version>='3.9'",
-    "pytest-cov>=5.0,<6; python_version>='3.8' and python_version<'3.9'",
-    "pytest-cov>=4.1,<5; python_version<'3.8'",
-    "pytest-describe>=3.0; python_version>='3.9'",
-    "pytest-describe>=2.2; python_version<'3.9'",
+    "anyio>=4.6",
+    "pytest>=8.4",
+    "pytest-benchmark>=5.2",
+    "pytest-cov>=6.0",
+    "pytest-describe>=3.0",
     "pytest-timeout>=2.4",
-    "pytest-codspeed>=3.1; python_version>='3.9'",
-    "pytest-codspeed>=2.2,<3; python_version<'3.8'",
-    "tox>=4.32; python_version>='3.10'",
-    "tox>=4.24; python_version>='3.8' and python_version<'3.10'",
-    "tox>=3.28,<4; python_version<'3.8'",
+    "pytest-codspeed>=3.1",
+    "tox>=4.32",
 ]
 lint = [
     "ruff>=0.14,<0.15",
-    "mypy>=1.18; python_version>='3.9'",
-    "mypy>=1.14; python_version>='3.8' and python_version<'3.9'",
-    "mypy>=1.4; python_version<'3.8'",
+    "mypy>=1.18",
     "bump2version>=1,<2",
 ]
 doc = [
-    "sphinx>=8,<10; python_version>='3.10'",
-    "sphinx>=7,<9; python_version>='3.8' and python_version<'3.10'",
-    "sphinx>=4,<6; python_version<'3.8'",
+    "sphinx>=8,<10",
     "sphinx_rtd_theme>=2,<4",
 ]
 
@@ -93,7 +73,7 @@ source-exclude = [
 
 [tool.ruff]
 line-length = 88
-target-version = "py37"
+target-version = "py310"
 
 [tool.ruff.lint]
 select = [

--- a/src/graphql/error/graphql_error.py
+++ b/src/graphql/error/graphql_error.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from sys import exc_info
-from typing import TYPE_CHECKING, Any, Collection, Dict
+from typing import TYPE_CHECKING, Any
 
 try:
     from typing import TypedDict
@@ -12,9 +12,11 @@ except ImportError:  # Python < 3.8
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from ..language.ast import Node
     from ..language.location import (
         FormattedSourceLocation,
@@ -26,7 +28,7 @@ __all__ = ["GraphQLError", "GraphQLErrorExtensions", "GraphQLFormattedError"]
 
 
 # Custom extensions
-GraphQLErrorExtensions: TypeAlias = Dict[str, Any]
+GraphQLErrorExtensions: TypeAlias = dict[str, Any]
 # Use a unique identifier name for your extension, for example the name of
 # your library or project. Do not use a shortened identifier as this increases
 # the risk of conflicts. We recommend you add at most one extension key,

--- a/src/graphql/error/located_error.py
+++ b/src/graphql/error/located_error.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from typing import TYPE_CHECKING, Collection
+from typing import TYPE_CHECKING
 
 from ..language.source import Source, is_source
 from ..pyutils import inspect
 from .graphql_error import GraphQLError
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from ..language.ast import Node
 
 __all__ = ["located_error"]

--- a/src/graphql/execution/async_iterables.py
+++ b/src/graphql/execution/async_iterables.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator, AsyncIterable, Awaitable, Callable
 from contextlib import AbstractAsyncContextManager, suppress
 from typing import (
-    AsyncGenerator,
-    AsyncIterable,
-    Awaitable,
-    Callable,
     Generic,
     TypeVar,
-    Union,
 )
 
 __all__ = ["aclosing", "map_async_iterable"]
@@ -18,7 +14,7 @@ __all__ = ["aclosing", "map_async_iterable"]
 T = TypeVar("T")
 V = TypeVar("V")
 
-AsyncIterableOrGenerator = Union[AsyncGenerator[T, None], AsyncIterable[T]]
+AsyncIterableOrGenerator = AsyncGenerator[T, None] | AsyncIterable[T]
 
 suppress_exceptions = suppress(Exception)
 

--- a/src/graphql/execution/build_field_plan.py
+++ b/src/graphql/execution/build_field_plan.py
@@ -10,7 +10,7 @@ from .collect_fields import DeferUsage, FieldGroup, GroupedFieldSet
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 __all__ = [
     "DeferUsageSet",

--- a/src/graphql/execution/collect_fields.py
+++ b/src/graphql/execution/collect_fields.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sys
 from collections import defaultdict
 from typing import Any, NamedTuple
 
@@ -29,7 +28,7 @@ from .values import get_directive_values
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 __all__ = [
     "CollectFieldsContext",
@@ -67,14 +66,8 @@ class FieldDetails(NamedTuple):
     defer_usage: DeferUsage | None
 
 
-if sys.version_info < (3, 9):
-    from typing import Dict, List
-
-    FieldGroup: TypeAlias = List[FieldDetails]
-    GroupedFieldSet: TypeAlias = Dict[str, FieldGroup]
-else:  # Python >= 3.9
-    FieldGroup: TypeAlias = list[FieldDetails]
-    GroupedFieldSet: TypeAlias = dict[str, FieldGroup]
+FieldGroup: TypeAlias = list[FieldDetails]
+GroupedFieldSet: TypeAlias = dict[str, FieldGroup]
 
 
 class CollectFieldsContext(NamedTuple):

--- a/src/graphql/execution/incremental_graph.py
+++ b/src/graphql/execution/incremental_graph.py
@@ -14,12 +14,6 @@ from asyncio import (
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
-    Awaitable,
-    Generator,
-    Iterable,
-    Sequence,
-    Union,
     cast,
 )
 
@@ -33,6 +27,9 @@ from .types import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Awaitable, Generator, Iterable, Sequence
+    from typing import TypeGuard
+
     from ..error.graphql_error import GraphQLError
     from .types import (
         DeferredFragmentRecord,
@@ -42,11 +39,6 @@ if TYPE_CHECKING:
         ReconcilableDeferredGroupedFieldSetResult,
         SubsequentResultRecord,
     )
-
-    try:
-        from typing import TypeGuard
-    except ImportError:  # Python < 3.10
-        from typing_extensions import TypeGuard
 
 __all__ = ["IncrementalGraph"]
 
@@ -74,7 +66,7 @@ class DeferredFragmentNode:
         self.children = []
 
 
-SubsequentResultNode = Union[DeferredFragmentNode, StreamRecord]
+SubsequentResultNode = DeferredFragmentNode | StreamRecord
 
 
 def is_deferred_fragment_node(

--- a/src/graphql/execution/incremental_publisher.py
+++ b/src/graphql/execution/incremental_publisher.py
@@ -7,9 +7,7 @@ from contextlib import suppress
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
     NamedTuple,
-    Sequence,
     cast,
 )
 
@@ -33,6 +31,8 @@ except ImportError:  # Python < 3.8
     from typing_extensions import Protocol
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Sequence
+
     from ..error import GraphQLError
     from .types import (
         CancellableStreamRecord,

--- a/src/graphql/execution/middleware.py
+++ b/src/graphql/execution/middleware.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Iterator
 from functools import partial, reduce
 from inspect import isfunction
-from typing import Any, Callable, Iterator
+from typing import Any
 
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ["MiddlewareManager"]

--- a/src/graphql/execution/types.py
+++ b/src/graphql/execution/types.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterator
 from typing import (
     TYPE_CHECKING,
     Any,
-    AsyncGenerator,
-    Awaitable,
-    Callable,
-    Iterator,
     NamedTuple,
     TypeVar,
-    Union,
 )
 
 try:
@@ -21,7 +17,7 @@ except ImportError:  # Python < 3.8
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 from ..pyutils import BoxedAwaitableOrValue, Undefined
 
@@ -32,7 +28,7 @@ if TYPE_CHECKING:
     try:
         from typing import TypeGuard
     except ImportError:  # Python < 3.10
-        from typing_extensions import TypeGuard
+        from typing import TypeGuard
     try:
         from typing import NotRequired
     except ImportError:  # Python < 3.11
@@ -582,11 +578,11 @@ class FormattedIncrementalStreamResult(TypedDict):
 
 T = TypeVar("T")  # declare T for generic aliases
 
-IncrementalResult: TypeAlias = Union[IncrementalDeferResult, IncrementalStreamResult]
+IncrementalResult: TypeAlias = IncrementalDeferResult | IncrementalStreamResult
 
-FormattedIncrementalResult: TypeAlias = Union[
-    FormattedIncrementalDeferResult, FormattedIncrementalStreamResult
-]
+FormattedIncrementalResult: TypeAlias = (
+    FormattedIncrementalDeferResult | FormattedIncrementalStreamResult
+)
 
 
 class PendingResult:  # noqa: PLW1641
@@ -767,10 +763,10 @@ def is_non_reconcilable_deferred_grouped_field_set_result(
     )
 
 
-DeferredGroupedFieldSetResult: TypeAlias = Union[
-    ReconcilableDeferredGroupedFieldSetResult,
-    NonReconcilableDeferredGroupedFieldSetResult,
-]
+DeferredGroupedFieldSetResult: TypeAlias = (
+    ReconcilableDeferredGroupedFieldSetResult
+    | NonReconcilableDeferredGroupedFieldSetResult
+)
 
 
 def is_deferred_grouped_field_set_result(
@@ -786,9 +782,9 @@ def is_deferred_grouped_field_set_result(
     )
 
 
-ThunkIncrementalResult: TypeAlias = Union[
-    BoxedAwaitableOrValue[T], Callable[[], BoxedAwaitableOrValue[T]]
-]
+ThunkIncrementalResult: TypeAlias = (
+    BoxedAwaitableOrValue[T] | Callable[[], BoxedAwaitableOrValue[T]]
+)
 
 
 class DeferredGroupedFieldSetRecord:
@@ -884,7 +880,7 @@ class StreamRecord:
         return f"{name}({', '.join(args)})"
 
 
-SubsequentResultRecord: TypeAlias = Union[DeferredFragmentRecord, StreamRecord]
+SubsequentResultRecord: TypeAlias = DeferredFragmentRecord | StreamRecord
 
 
 class CancellableStreamRecord(StreamRecord):
@@ -921,8 +917,8 @@ class StreamItemsResult(NamedTuple):
     errors: list[GraphQLError] | None = None
 
 
-IncrementalDataRecord: TypeAlias = Union[DeferredGroupedFieldSetRecord, StreamRecord]
+IncrementalDataRecord: TypeAlias = DeferredGroupedFieldSetRecord | StreamRecord
 
-IncrementalDataRecordResult: TypeAlias = Union[
-    DeferredGroupedFieldSetResult, StreamItemsResult
-]
+IncrementalDataRecordResult: TypeAlias = (
+    DeferredGroupedFieldSetResult | StreamItemsResult
+)

--- a/src/graphql/execution/values.py
+++ b/src/graphql/execution/values.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Collection, Dict, List, Union
+from typing import TYPE_CHECKING, Any
 
 from ..error import GraphQLError
 from ..language import (
@@ -34,14 +34,17 @@ from ..utilities.coerce_input_value import coerce_input_value
 from ..utilities.type_from_ast import type_from_ast
 from ..utilities.value_from_ast import value_from_ast
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
+
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 __all__ = ["get_argument_values", "get_directive_values", "get_variable_values"]
 
-CoercedVariableValues: TypeAlias = Union[List[GraphQLError], Dict[str, Any]]
+CoercedVariableValues: TypeAlias = list[GraphQLError] | dict[str, Any]
 
 
 def get_variable_values(
@@ -224,16 +227,16 @@ def get_argument_values(
     return coerced_values
 
 
-NodeWithDirective: TypeAlias = Union[
-    EnumValueDefinitionNode,
-    ExecutableDefinitionNode,
-    FieldDefinitionNode,
-    InputValueDefinitionNode,
-    SelectionNode,
-    SchemaDefinitionNode,
-    TypeDefinitionNode,
-    TypeExtensionNode,
-]
+NodeWithDirective: TypeAlias = (
+    EnumValueDefinitionNode
+    | ExecutableDefinitionNode
+    | FieldDefinitionNode
+    | InputValueDefinitionNode
+    | SelectionNode
+    | SchemaDefinitionNode
+    | TypeDefinitionNode
+    | TypeExtensionNode
+)
 
 
 def get_directive_values(

--- a/src/graphql/graphql.py
+++ b/src/graphql/graphql.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from asyncio import ensure_future
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from .error import GraphQLError
 from .execution import ExecutionContext, ExecutionResult, Middleware, execute
@@ -17,12 +17,14 @@ from .type import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from .pyutils import AwaitableOrValue
 
     try:
         from typing import TypeGuard
     except ImportError:  # Python < 3.10
-        from typing_extensions import TypeGuard
+        from typing import TypeGuard
 
 __all__ = ["graphql", "graphql_sync"]
 

--- a/src/graphql/language/ast.py
+++ b/src/graphql/language/ast.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 from copy import copy, deepcopy
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Union
+from typing import TYPE_CHECKING, Any
 
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 from ..pyutils import camel_to_snake
 
@@ -632,16 +632,16 @@ class ConstObjectFieldNode(ObjectFieldNode):
     value: ConstValueNode
 
 
-ConstValueNode: TypeAlias = Union[
-    IntValueNode,
-    FloatValueNode,
-    StringValueNode,
-    BooleanValueNode,
-    NullValueNode,
-    EnumValueNode,
-    ConstListValueNode,
-    ConstObjectValueNode,
-]
+ConstValueNode: TypeAlias = (
+    IntValueNode
+    | FloatValueNode
+    | StringValueNode
+    | BooleanValueNode
+    | NullValueNode
+    | EnumValueNode
+    | ConstListValueNode
+    | ConstObjectValueNode
+)
 
 
 # Directives
@@ -820,7 +820,7 @@ class TypeExtensionNode(TypeSystemDefinitionNode):
     directives: tuple[ConstDirectiveNode, ...]
 
 
-TypeSystemExtensionNode: TypeAlias = Union[SchemaExtensionNode, TypeExtensionNode]
+TypeSystemExtensionNode: TypeAlias = SchemaExtensionNode | TypeExtensionNode
 
 
 class ScalarTypeExtensionNode(TypeExtensionNode):

--- a/src/graphql/language/block_string.py
+++ b/src/graphql/language/block_string.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from sys import maxsize
-from typing import Collection
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 __all__ = [
     "dedent_block_string_lines",

--- a/src/graphql/language/parser.py
+++ b/src/graphql/language/parser.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable, Mapping, TypeVar, Union, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 
 from ..error import GraphQLError, GraphQLSyntaxError
 from .ast import (
@@ -71,17 +71,20 @@ from .lexer import Lexer, is_punctuator_token_kind
 from .source import Source, is_source
 from .token_kind import TokenKind
 
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ["parse", "parse_const_value", "parse_type", "parse_value"]
 
 T = TypeVar("T")
 
-SourceType: TypeAlias = Union[Source, str]
+SourceType: TypeAlias = Source | str
 
 
 def parse(

--- a/src/graphql/language/predicates.py
+++ b/src/graphql/language/predicates.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TypeGuard
+
 from .ast import (
     DefinitionNode,
     ExecutableDefinitionNode,
@@ -9,21 +11,15 @@ from .ast import (
     Node,
     NullabilityAssertionNode,
     ObjectValueNode,
-    SchemaExtensionNode,
     SelectionNode,
     TypeDefinitionNode,
     TypeExtensionNode,
     TypeNode,
     TypeSystemDefinitionNode,
+    TypeSystemExtensionNode,
     ValueNode,
     VariableNode,
 )
-
-try:
-    from typing import TypeGuard
-except ImportError:  # Python < 3.10
-    from typing import TypeGuard
-
 
 __all__ = [
     "is_const_value_node",
@@ -93,9 +89,9 @@ def is_type_definition_node(node: Node) -> TypeGuard[TypeDefinitionNode]:
 
 def is_type_system_extension_node(
     node: Node,
-) -> TypeGuard[SchemaExtensionNode | TypeExtensionNode]:
+) -> TypeGuard[TypeSystemExtensionNode]:
     """Check whether the given node represents a type system extension."""
-    return isinstance(node, (SchemaExtensionNode, TypeExtensionNode))
+    return isinstance(node, TypeSystemExtensionNode)
 
 
 def is_type_extension_node(node: Node) -> TypeGuard[TypeExtensionNode]:

--- a/src/graphql/language/predicates.py
+++ b/src/graphql/language/predicates.py
@@ -22,7 +22,7 @@ from .ast import (
 try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 
 __all__ = [

--- a/src/graphql/language/print_location.py
+++ b/src/graphql/language/print_location.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, Tuple, cast
+from typing import TYPE_CHECKING, cast
 
 from .location import SourceLocation, get_location
 
@@ -73,7 +73,7 @@ def print_source_location(source: Source, source_location: SourceLocation) -> st
 def print_prefixed_lines(*lines: tuple[str, str | None]) -> str:
     """Print lines specified like this: ("prefix", "string")"""
     existing_lines = [
-        cast("Tuple[str, str]", line) for line in lines if line[1] is not None
+        cast("tuple[str, str]", line) for line in lines if line[1] is not None
     ]
     pad_len = max(len(line[0]) for line in existing_lines)
     return "\n".join(

--- a/src/graphql/language/printer.py
+++ b/src/graphql/language/printer.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Collection
+from collections.abc import Collection
+from typing import TYPE_CHECKING, Any
 
 from .block_string import print_block_string
 from .print_string import print_string
@@ -14,7 +15,7 @@ if TYPE_CHECKING:
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ["print_ast"]

--- a/src/graphql/language/source.py
+++ b/src/graphql/language/source.py
@@ -9,7 +9,7 @@ from .location import SourceLocation
 try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 __all__ = ["Source", "is_source"]
 

--- a/src/graphql/language/visitor.py
+++ b/src/graphql/language/visitor.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from copy import copy
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
@@ -225,9 +224,11 @@ def visit(
                             node[array_key] = edit_value
                     node = tuple(node)
                 else:
-                    node = copy(node)
+                    # Create new node with edited values (immutable-friendly)
+                    values = {k: getattr(node, k) for k in node.keys}
                     for edit_key, edit_value in edits:
-                        setattr(node, edit_key, edit_value)
+                        values[edit_key] = edit_value
+                    node = node.__class__(**values)
             idx = stack.idx
             keys = stack.keys
             edits = stack.edits

--- a/src/graphql/language/visitor.py
+++ b/src/graphql/language/visitor.py
@@ -5,24 +5,18 @@ from __future__ import annotations
 from copy import copy
 from enum import Enum
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Callable,
-    Collection,
-    Dict,
     NamedTuple,
-    Optional,
-    Tuple,
+    TypeAlias,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
 
 from ..pyutils import inspect, snake_to_camel
 from . import ast
 from .ast import QUERY_DOCUMENT_KEYS, Node
-
-try:
-    from typing import TypeAlias
-except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
-
 
 __all__ = [
     "BREAK",
@@ -48,7 +42,7 @@ class VisitorActionEnum(Enum):
     REMOVE = Ellipsis
 
 
-VisitorAction: TypeAlias = Optional[VisitorActionEnum]
+VisitorAction: TypeAlias = VisitorActionEnum | None
 
 # Note that in GraphQL.js these are defined *differently*:
 # BREAK = {}, SKIP = false, REMOVE = null, IDLE = undefined
@@ -58,7 +52,7 @@ SKIP = VisitorActionEnum.SKIP
 REMOVE = VisitorActionEnum.REMOVE
 IDLE = None
 
-VisitorKeyMap: TypeAlias = Dict[str, Tuple[str, ...]]
+VisitorKeyMap: TypeAlias = dict[str, tuple[str, ...]]
 
 
 class EnterLeaveVisitor(NamedTuple):

--- a/src/graphql/language/visitor.py
+++ b/src/graphql/language/visitor.py
@@ -10,6 +10,8 @@ from typing import (
     TypeAlias,
 )
 
+import msgspec.structs
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection
 
@@ -225,10 +227,7 @@ def visit(
                     node = tuple(node)
                 else:
                     # Create new node with edited values (immutable-friendly)
-                    values = {k: getattr(node, k) for k in node.keys}
-                    for edit_key, edit_value in edits:
-                        values[edit_key] = edit_value
-                    node = node.__class__(**values)
+                    node = msgspec.structs.replace(node, **dict(edits))
             idx = stack.idx
             keys = stack.keys
             edits = stack.edits

--- a/src/graphql/pyutils/async_reduce.py
+++ b/src/graphql/pyutils/async_reduce.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Awaitable, Callable, Collection, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from .is_awaitable import is_awaitable as default_is_awaitable
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Collection
+
     from .awaitable_or_value import AwaitableOrValue
 
     try:
         from typing import TypeGuard
     except ImportError:  # Python < 3.10
-        from typing_extensions import TypeGuard
+        from typing import TypeGuard
 
 __all__ = ["async_reduce"]
 

--- a/src/graphql/pyutils/awaitable_or_value.py
+++ b/src/graphql/pyutils/awaitable_or_value.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Awaitable, TypeVar, Union
+from collections.abc import Awaitable
+from typing import TypeVar
 
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ["AwaitableOrValue"]
@@ -15,4 +16,4 @@ __all__ = ["AwaitableOrValue"]
 
 T = TypeVar("T")
 
-AwaitableOrValue: TypeAlias = Union[Awaitable[T], T]
+AwaitableOrValue: TypeAlias = Awaitable[T] | T

--- a/src/graphql/pyutils/boxed_awaitable_or_value.py
+++ b/src/graphql/pyutils/boxed_awaitable_or_value.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from asyncio import CancelledError, Future, ensure_future, isfuture
 from contextlib import suppress
-from typing import Awaitable, Generic, TypeVar
+from typing import TYPE_CHECKING, Generic, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
 __all__ = ["BoxedAwaitableOrValue"]
 

--- a/src/graphql/pyutils/cached_property.py
+++ b/src/graphql/pyutils/cached_property.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     standard_cached_property = None
 else:
     try:

--- a/src/graphql/pyutils/did_you_mean.py
+++ b/src/graphql/pyutils/did_you_mean.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING
 
 from .format_list import or_list
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __all__ = ["did_you_mean"]
 

--- a/src/graphql/pyutils/format_list.py
+++ b/src/graphql/pyutils/format_list.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 __all__ = ["and_list", "or_list"]
 

--- a/src/graphql/pyutils/gather_with_cancel.py
+++ b/src/graphql/pyutils/gather_with_cancel.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from asyncio import Task, create_task, gather
-from typing import Any, Awaitable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
 __all__ = ["gather_with_cancel"]
 

--- a/src/graphql/pyutils/group_by.py
+++ b/src/graphql/pyutils/group_by.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Callable, Collection, TypeVar
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
 
 __all__ = ["group_by"]
 

--- a/src/graphql/pyutils/is_awaitable.py
+++ b/src/graphql/pyutils/is_awaitable.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 import inspect
 from types import CoroutineType, GeneratorType
-from typing import Any, Awaitable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
 try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 
 __all__ = ["is_awaitable"]

--- a/src/graphql/pyutils/is_iterable.py
+++ b/src/graphql/pyutils/is_iterable.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 from array import array
-from typing import Any, Collection, Iterable, Mapping, ValuesView
+from collections.abc import Collection, Iterable, Mapping, ValuesView
+from typing import Any
 
 try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 
 __all__ = ["is_collection", "is_iterable"]

--- a/src/graphql/pyutils/merge_kwargs.py
+++ b/src/graphql/pyutils/merge_kwargs.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, TypeVar, cast
+from typing import Any, TypeVar, cast
 
 T = TypeVar("T")
 
 
 def merge_kwargs(base_dict: T, **kwargs: Any) -> T:
     """Return arbitrary typed dictionary with some keyword args merged in."""
-    return cast("T", {**cast("Dict", base_dict), **kwargs})
+    return cast("T", {**cast("dict", base_dict), **kwargs})

--- a/src/graphql/pyutils/print_path_list.py
+++ b/src/graphql/pyutils/print_path_list.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Collection
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 
 def print_path_list(path: Collection[str | int]) -> str:

--- a/src/graphql/pyutils/ref_map.py
+++ b/src/graphql/pyutils/ref_map.py
@@ -7,8 +7,9 @@ from collections.abc import MutableMapping
 try:
     MutableMapping[str, int]
 except TypeError:  # Python < 3.9
-    from typing import MutableMapping
-from typing import Any, Iterable, Iterator, TypeVar
+    from collections.abc import MutableMapping
+from collections.abc import Iterable, Iterator
+from typing import Any, TypeVar
 
 __all__ = ["RefMap"]
 

--- a/src/graphql/pyutils/ref_set.py
+++ b/src/graphql/pyutils/ref_set.py
@@ -7,9 +7,10 @@ from collections.abc import MutableSet
 try:
     MutableSet[int]
 except TypeError:  # Python < 3.9
-    from typing import MutableSet
+    from collections.abc import MutableSet
+from collections.abc import Iterable, Iterator
 from contextlib import suppress
-from typing import Any, Iterable, Iterator, TypeVar
+from typing import Any, TypeVar
 
 from .ref_map import RefMap
 

--- a/src/graphql/pyutils/simple_pub_sub.py
+++ b/src/graphql/pyutils/simple_pub_sub.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from asyncio import Future, Queue, create_task, get_running_loop, sleep
-from typing import Any, AsyncIterator, Callable
+from collections.abc import AsyncIterator, Callable
+from typing import Any
 
 from .is_awaitable import is_awaitable
 

--- a/src/graphql/pyutils/suggestion_list.py
+++ b/src/graphql/pyutils/suggestion_list.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Collection
+from typing import TYPE_CHECKING
 
 from .natural_compare import natural_comparison_key
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 __all__ = ["suggestion_list"]
 

--- a/src/graphql/type/definition.py
+++ b/src/graphql/type/definition.py
@@ -2,21 +2,14 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable, Callable, Collection, Mapping
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
     Any,
-    Awaitable,
-    Callable,
-    Collection,
-    Dict,
     Generic,
-    Mapping,
     NamedTuple,
-    Optional,
-    Type,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -30,7 +23,7 @@ if TYPE_CHECKING:
     try:
         from typing import TypeAlias, TypeGuard
     except ImportError:  # Python < 3.10
-        from typing_extensions import TypeAlias, TypeGuard
+        from typing import TypeAlias, TypeGuard
 
 from ..error import GraphQLError
 from ..language import (
@@ -302,9 +295,9 @@ class GraphQLNamedType(GraphQLType):
 
 T = TypeVar("T")
 
-ThunkCollection: TypeAlias = Union[Callable[[], Collection[T]], Collection[T]]
-ThunkMapping: TypeAlias = Union[Callable[[], Mapping[str, T]], Mapping[str, T]]
-Thunk: TypeAlias = Union[Callable[[], T], T]
+ThunkCollection: TypeAlias = Callable[[], Collection[T]] | Collection[T]
+ThunkMapping: TypeAlias = Callable[[], Mapping[str, T]] | Mapping[str, T]
+Thunk: TypeAlias = Callable[[], T] | T
 
 
 def resolve_thunk(thunk: Thunk[T]) -> T:
@@ -319,7 +312,7 @@ def resolve_thunk(thunk: Thunk[T]) -> T:
 GraphQLScalarSerializer: TypeAlias = Callable[[Any], Any]
 GraphQLScalarValueParser: TypeAlias = Callable[[Any], Any]
 GraphQLScalarLiteralParser: TypeAlias = Callable[
-    [ValueNode, Optional[Dict[str, Any]]], Any
+    [ValueNode, dict[str, Any] | None], Any
 ]
 
 
@@ -465,7 +458,7 @@ def assert_scalar_type(type_: Any) -> GraphQLScalarType:
     return type_
 
 
-GraphQLArgumentMap: TypeAlias = Dict[str, "GraphQLArgument"]
+GraphQLArgumentMap: TypeAlias = dict[str, "GraphQLArgument"]
 
 
 class GraphQLFieldKwargs(TypedDict, total=False):
@@ -622,7 +615,7 @@ GraphQLFieldResolver: TypeAlias = Callable[..., Any]
 # the context is passed as part of the GraphQLResolveInfo:
 GraphQLTypeResolver: TypeAlias = Callable[
     [Any, GraphQLResolveInfo, "GraphQLAbstractType"],
-    AwaitableOrValue[Optional[str]],
+    AwaitableOrValue[str | None],
 ]
 
 # Note: Contrary to the Javascript implementation of GraphQLIsTypeOfFn,
@@ -631,7 +624,7 @@ GraphQLIsTypeOfFn: TypeAlias = Callable[
     [Any, GraphQLResolveInfo], AwaitableOrValue[bool]
 ]
 
-GraphQLFieldMap: TypeAlias = Dict[str, GraphQLField]
+GraphQLFieldMap: TypeAlias = dict[str, GraphQLField]
 
 
 class GraphQLArgumentKwargs(TypedDict, total=False):
@@ -1013,11 +1006,11 @@ def assert_union_type(type_: Any) -> GraphQLUnionType:
     return type_
 
 
-GraphQLEnumValueMap: TypeAlias = Dict[str, "GraphQLEnumValue"]
+GraphQLEnumValueMap: TypeAlias = dict[str, "GraphQLEnumValue"]
 
-GraphQLEnumValuesDefinition: TypeAlias = Union[
-    GraphQLEnumValueMap, Mapping[str, Any], Type[Enum]
-]
+GraphQLEnumValuesDefinition: TypeAlias = (
+    GraphQLEnumValueMap | Mapping[str, Any] | type[Enum]
+)
 
 
 class GraphQLEnumTypeKwargs(GraphQLNamedTypeKwargs, total=False):
@@ -1098,9 +1091,9 @@ class GraphQLEnumType(GraphQLNamedType):
                         " with value names as keys."
                     )
                     raise TypeError(msg) from error
-            values = cast("Dict[str, Any]", values)
+            values = cast("dict[str, Any]", values)
         else:
-            values = cast("Dict[str, Enum]", values)
+            values = cast("dict[str, Enum]", values)
             if names_as_values is False:
                 values = {key: value.value for key, value in values.items()}
             elif names_as_values is True:
@@ -1269,8 +1262,8 @@ class GraphQLEnumValue:  # noqa: PLW1641
         return self.__class__(**self.to_kwargs())
 
 
-GraphQLInputFieldMap: TypeAlias = Dict[str, "GraphQLInputField"]
-GraphQLInputFieldOutType = Callable[[Dict[str, Any]], Any]
+GraphQLInputFieldMap: TypeAlias = dict[str, "GraphQLInputField"]
+GraphQLInputFieldOutType = Callable[[dict[str, Any]], Any]
 
 
 class GraphQLInputObjectTypeKwargs(GraphQLNamedTypeKwargs, total=False):
@@ -1532,45 +1525,40 @@ class GraphQLNonNull(GraphQLWrappingType[GNT_co]):
 
 # These types can all accept null as a value.
 
-GraphQLNullableType: TypeAlias = Union[
-    GraphQLScalarType,
-    GraphQLObjectType,
-    GraphQLInterfaceType,
-    GraphQLUnionType,
-    GraphQLEnumType,
-    GraphQLInputObjectType,
-    GraphQLList,
-]
+GraphQLNullableType: TypeAlias = (
+    GraphQLScalarType
+    | GraphQLObjectType
+    | GraphQLInterfaceType
+    | GraphQLUnionType
+    | GraphQLEnumType
+    | GraphQLInputObjectType
+    | GraphQLList
+)
 
 # These types may be used as input types for arguments and directives.
 
-GraphQLNullableInputType: TypeAlias = Union[
-    GraphQLScalarType,
-    GraphQLEnumType,
-    GraphQLInputObjectType,
-    # actually GraphQLList[GraphQLInputType], but we can't recurse
-    GraphQLList,
-]
+GraphQLNullableInputType: TypeAlias = (
+    GraphQLScalarType | GraphQLEnumType | GraphQLInputObjectType | GraphQLList
+)
 
-GraphQLInputType: TypeAlias = Union[
-    GraphQLNullableInputType, GraphQLNonNull[GraphQLNullableInputType]
-]
+GraphQLInputType: TypeAlias = (
+    GraphQLNullableInputType | GraphQLNonNull[GraphQLNullableInputType]
+)
 
 # These types may be used as output types as the result of fields.
 
-GraphQLNullableOutputType: TypeAlias = Union[
-    GraphQLScalarType,
-    GraphQLObjectType,
-    GraphQLInterfaceType,
-    GraphQLUnionType,
-    GraphQLEnumType,
-    # actually GraphQLList[GraphQLOutputType], but we can't recurse
-    GraphQLList,
-]
+GraphQLNullableOutputType: TypeAlias = (
+    GraphQLScalarType
+    | GraphQLObjectType
+    | GraphQLInterfaceType
+    | GraphQLUnionType
+    | GraphQLEnumType
+    | GraphQLList
+)
 
-GraphQLOutputType: TypeAlias = Union[
-    GraphQLNullableOutputType, GraphQLNonNull[GraphQLNullableOutputType]
-]
+GraphQLOutputType: TypeAlias = (
+    GraphQLNullableOutputType | GraphQLNonNull[GraphQLNullableOutputType]
+)
 
 
 # Predicates and Assertions
@@ -1668,22 +1656,22 @@ def get_nullable_type(
     """Unwrap possible non-null type"""
     if is_non_null_type(type_):
         type_ = type_.of_type
-    return cast("Optional[GraphQLNullableType]", type_)
+    return cast("GraphQLNullableType | None", type_)
 
 
 # These named types do not include modifiers like List or NonNull.
 
-GraphQLNamedInputType: TypeAlias = Union[
-    GraphQLScalarType, GraphQLEnumType, GraphQLInputObjectType
-]
+GraphQLNamedInputType: TypeAlias = (
+    GraphQLScalarType | GraphQLEnumType | GraphQLInputObjectType
+)
 
-GraphQLNamedOutputType: TypeAlias = Union[
-    GraphQLScalarType,
-    GraphQLObjectType,
-    GraphQLInterfaceType,
-    GraphQLUnionType,
-    GraphQLEnumType,
-]
+GraphQLNamedOutputType: TypeAlias = (
+    GraphQLScalarType
+    | GraphQLObjectType
+    | GraphQLInterfaceType
+    | GraphQLUnionType
+    | GraphQLEnumType
+)
 
 
 def is_named_type(type_: Any) -> TypeGuard[GraphQLNamedType]:
@@ -1719,7 +1707,7 @@ def get_named_type(type_: GraphQLType | None) -> GraphQLNamedType | None:
 
 # These types may describe types which may be leaf values.
 
-GraphQLLeafType: TypeAlias = Union[GraphQLScalarType, GraphQLEnumType]
+GraphQLLeafType: TypeAlias = GraphQLScalarType | GraphQLEnumType
 
 
 def is_leaf_type(type_: Any) -> TypeGuard[GraphQLLeafType]:
@@ -1737,9 +1725,9 @@ def assert_leaf_type(type_: Any) -> GraphQLLeafType:
 
 # These types may describe the parent context of a selection set.
 
-GraphQLCompositeType: TypeAlias = Union[
-    GraphQLObjectType, GraphQLInterfaceType, GraphQLUnionType
-]
+GraphQLCompositeType: TypeAlias = (
+    GraphQLObjectType | GraphQLInterfaceType | GraphQLUnionType
+)
 
 
 def is_composite_type(type_: Any) -> TypeGuard[GraphQLCompositeType]:
@@ -1759,7 +1747,7 @@ def assert_composite_type(type_: Any) -> GraphQLCompositeType:
 
 # These types may describe abstract types.
 
-GraphQLAbstractType: TypeAlias = Union[GraphQLInterfaceType, GraphQLUnionType]
+GraphQLAbstractType: TypeAlias = GraphQLInterfaceType | GraphQLUnionType
 
 
 def is_abstract_type(type_: Any) -> TypeGuard[GraphQLAbstractType]:

--- a/src/graphql/type/directives.py
+++ b/src/graphql/type/directives.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
-from typing import Any, Collection, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ..language import DirectiveLocation, ast
 from ..pyutils import inspect
 from .assert_name import assert_name
 from .definition import GraphQLArgument, GraphQLInputType, GraphQLNonNull
 from .scalars import GraphQLBoolean, GraphQLInt, GraphQLString
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 try:
     from typing import TypedDict
@@ -17,7 +20,7 @@ except ImportError:  # Python < 3.8
 try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 __all__ = [
     "DEFAULT_DEPRECATION_REASON",

--- a/src/graphql/type/introspection.py
+++ b/src/graphql/type/introspection.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Mapping
+from typing import TYPE_CHECKING
 
 from ..language import DirectiveLocation, print_ast
 from ..pyutils import inspect
@@ -28,6 +28,9 @@ from .definition import (
     is_union_type,
 )
 from .scalars import GraphQLBoolean, GraphQLString
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = [
     "SchemaMetaFieldDef",

--- a/src/graphql/type/scalars.py
+++ b/src/graphql/type/scalars.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from math import isfinite
-from typing import Any, Mapping
+from typing import TYPE_CHECKING, Any
 
 from ..error import GraphQLError
 from ..language.ast import (
@@ -17,10 +17,13 @@ from ..language.printer import print_ast
 from ..pyutils import inspect
 from .definition import GraphQLNamedType, GraphQLScalarType
 
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
 try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 __all__ = [
     "GRAPHQL_MAX_INT",

--- a/src/graphql/type/schema.py
+++ b/src/graphql/type/schema.py
@@ -6,13 +6,13 @@ from copy import copy, deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
-    Collection,
-    Dict,
     NamedTuple,
     cast,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from ..error import GraphQLError
     from ..language import OperationType, ast
 
@@ -48,11 +48,11 @@ except ImportError:  # Python < 3.8
 try:
     from typing import TypeAlias, TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias, TypeGuard
+    from typing import TypeAlias, TypeGuard
 
 __all__ = ["GraphQLSchema", "GraphQLSchemaKwargs", "assert_schema", "is_schema"]
 
-TypeMap: TypeAlias = Dict[str, GraphQLNamedType]
+TypeMap: TypeAlias = dict[str, GraphQLNamedType]
 
 
 class InterfaceImplementations(NamedTuple):
@@ -406,7 +406,7 @@ class GraphQLSchema:
         return self._validation_errors
 
 
-class TypeSet(Dict[GraphQLNamedType, None]):
+class TypeSet(dict[GraphQLNamedType, None]):
     """An ordered set of types that can be collected starting from initial types."""
 
     @classmethod

--- a/src/graphql/type/validate.py
+++ b/src/graphql/type/validate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from operator import attrgetter, itemgetter
-from typing import Any, Collection, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ..error import GraphQLError
 from ..language import (
@@ -40,6 +40,9 @@ from .definition import (
 from .directives import GraphQLDeprecatedDirective, is_directive
 from .introspection import is_introspection_type
 from .schema import GraphQLSchema, assert_schema
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 __all__ = ["assert_valid_schema", "validate_schema"]
 
@@ -100,7 +103,7 @@ class SchemaValidationContext:
     ) -> None:
         if nodes and not isinstance(nodes, Node):
             nodes = [node for node in nodes if node]
-        nodes = cast("Optional[Collection[Node]]", nodes)
+        nodes = cast("Collection[Node] | None", nodes)
         self.errors.append(GraphQLError(message, nodes))
 
     def validate_root_types(self) -> None:

--- a/src/graphql/utilities/ast_from_value.py
+++ b/src/graphql/utilities/ast_from_value.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from math import isfinite
-from typing import Any, Mapping
+from typing import Any
 
 from ..language import (
     BooleanValueNode,

--- a/src/graphql/utilities/ast_to_dict.py
+++ b/src/graphql/utilities/ast_to_dict.py
@@ -45,14 +45,18 @@ def ast_to_dict(
         elif node in cache:
             return cache[node]
         cache[node] = res = {}
+        # Note: We don't use msgspec.structs.asdict() because loc needs special
+        # handling (converted to {start, end} dict rather than full Location object)
+        # Filter out 'loc' - it's handled separately for the locations option
+        fields = [f for f in node.keys if f != "loc"]
         res.update(
             {
                 key: ast_to_dict(getattr(node, key), locations, cache)
-                for key in ("kind", *node.keys[1:])
+                for key in ("kind", *fields)
             }
         )
         if locations:
-            loc = node.loc
+            loc = getattr(node, "loc", None)
             if loc:
                 res["loc"] = {"start": loc.start, "end": loc.end}
         return res

--- a/src/graphql/utilities/ast_to_dict.py
+++ b/src/graphql/utilities/ast_to_dict.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any, Collection, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from ..language import Node, OperationType
 from ..pyutils import is_iterable
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 __all__ = ["ast_to_dict"]
 

--- a/src/graphql/utilities/build_client_schema.py
+++ b/src/graphql/utilities/build_client_schema.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import TYPE_CHECKING, Callable, Collection, cast
+from typing import TYPE_CHECKING, cast
 
 from ..language import DirectiveLocation, parse_value
 from ..pyutils import Undefined, inspect
@@ -36,6 +36,8 @@ from ..type import (
 from .value_from_ast import value_from_ast
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Collection
+
     from .get_introspection_query import (
         IntrospectionDirective,
         IntrospectionEnumType,

--- a/src/graphql/utilities/coerce_input_value.py
+++ b/src/graphql/utilities/coerce_input_value.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, List, Union, cast
+from collections.abc import Callable
+from typing import Any, cast
 
 from ..error import GraphQLError
 from ..pyutils import (
@@ -26,13 +27,13 @@ from ..type import (
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ["coerce_input_value"]
 
 
-OnErrorCB: TypeAlias = Callable[[List[Union[str, int]], Any, GraphQLError], None]
+OnErrorCB: TypeAlias = Callable[[list[str | int], Any, GraphQLError], None]
 
 
 def default_on_error(

--- a/src/graphql/utilities/concat_ast.py
+++ b/src/graphql/utilities/concat_ast.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import Collection
+from typing import TYPE_CHECKING
 
 from ..language.ast import DocumentNode
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 __all__ = ["concat_ast"]
 

--- a/src/graphql/utilities/concat_ast.py
+++ b/src/graphql/utilities/concat_ast.py
@@ -17,6 +17,5 @@ def concat_ast(asts: Collection[DocumentNode]) -> DocumentNode:
     the ASTs together into batched AST, useful for validating many GraphQL source files
     which together represent one conceptual application.
     """
-    return DocumentNode(
-        definitions=list(chain.from_iterable(document.definitions for document in asts))
-    )
+    all_definitions = chain.from_iterable(doc.definitions for doc in asts)
+    return DocumentNode(definitions=tuple(all_definitions))

--- a/src/graphql/utilities/extend_schema.py
+++ b/src/graphql/utilities/extend_schema.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 from collections import defaultdict
 from functools import partial
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Collection,
-    Mapping,
     TypeVar,
     cast,
 )
@@ -90,6 +89,9 @@ from ..type import (
     specified_scalar_types,
 )
 from .value_from_ast import value_from_ast
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping
 
 __all__ = [
     "ExtendSchemaImpl",

--- a/src/graphql/utilities/extend_schema.py
+++ b/src/graphql/utilities/extend_schema.py
@@ -547,7 +547,7 @@ class ExtendSchemaImpl:
             return GraphQLNonNull(
                 cast("GraphQLNullableType", self.get_wrapped_type(node.type))
             )
-        return self.get_named_type(cast("NamedTypeNode", node))
+        return self.get_named_type(node)
 
     def build_directive(self, node: DirectiveDefinitionNode) -> GraphQLDirective:
         """Build a GraphQL directive for a given directive definition node."""

--- a/src/graphql/utilities/find_breaking_changes.py
+++ b/src/graphql/utilities/find_breaking_changes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Collection, NamedTuple, Union
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from ..language import print_ast
 from ..pyutils import Undefined, inspect
@@ -34,10 +34,13 @@ from ..type import (
 from ..utilities.sort_value_node import sort_value_node
 from .ast_from_value import ast_from_value
 
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = [
@@ -96,7 +99,7 @@ class DangerousChange(NamedTuple):
     description: str
 
 
-Change: TypeAlias = Union[BreakingChange, DangerousChange]
+Change: TypeAlias = BreakingChange | DangerousChange
 
 
 def find_breaking_changes(

--- a/src/graphql/utilities/get_introspection_query.py
+++ b/src/graphql/utilities/get_introspection_query.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from textwrap import dedent
-from typing import TYPE_CHECKING, Any, Dict, Union
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..language import DirectiveLocation
@@ -11,11 +11,13 @@ if TYPE_CHECKING:
 try:
     from typing import Literal, TypedDict
 except ImportError:  # Python < 3.8
-    from typing_extensions import Literal, TypedDict
+    from typing import Literal
+
+    from typing_extensions import TypedDict
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 __all__ = [
     "IntrospectionDirective",
@@ -177,7 +179,7 @@ def get_introspection_query(
 # - no generic typed dicts, see https://github.com/python/mypy/issues/3863
 
 # simplified IntrospectionNamedType to avoids cycles
-SimpleIntrospectionType: TypeAlias = Dict[str, Any]
+SimpleIntrospectionType: TypeAlias = dict[str, Any]
 
 
 class MaybeWithDescription(TypedDict, total=False):
@@ -258,26 +260,26 @@ class IntrospectionInputObjectType(WithName):
     isOneOf: bool
 
 
-IntrospectionType: TypeAlias = Union[
-    IntrospectionScalarType,
-    IntrospectionObjectType,
-    IntrospectionInterfaceType,
-    IntrospectionUnionType,
-    IntrospectionEnumType,
-    IntrospectionInputObjectType,
-]
+IntrospectionType: TypeAlias = (
+    IntrospectionScalarType
+    | IntrospectionObjectType
+    | IntrospectionInterfaceType
+    | IntrospectionUnionType
+    | IntrospectionEnumType
+    | IntrospectionInputObjectType
+)
 
-IntrospectionOutputType: TypeAlias = Union[
-    IntrospectionScalarType,
-    IntrospectionObjectType,
-    IntrospectionInterfaceType,
-    IntrospectionUnionType,
-    IntrospectionEnumType,
-]
+IntrospectionOutputType: TypeAlias = (
+    IntrospectionScalarType
+    | IntrospectionObjectType
+    | IntrospectionInterfaceType
+    | IntrospectionUnionType
+    | IntrospectionEnumType
+)
 
-IntrospectionInputType: TypeAlias = Union[
-    IntrospectionScalarType, IntrospectionEnumType, IntrospectionInputObjectType
-]
+IntrospectionInputType: TypeAlias = (
+    IntrospectionScalarType | IntrospectionEnumType | IntrospectionInputObjectType
+)
 
 
 class IntrospectionListType(TypedDict):
@@ -290,9 +292,9 @@ class IntrospectionNonNullType(TypedDict):
     ofType: SimpleIntrospectionType  # should be IntrospectionType
 
 
-IntrospectionTypeRef: TypeAlias = Union[
-    IntrospectionType, IntrospectionListType, IntrospectionNonNullType
-]
+IntrospectionTypeRef: TypeAlias = (
+    IntrospectionType | IntrospectionListType | IntrospectionNonNullType
+)
 
 
 class IntrospectionSchema(MaybeWithDescription):

--- a/src/graphql/utilities/lexicographic_sort_schema.py
+++ b/src/graphql/utilities/lexicographic_sort_schema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 from ..pyutils import inspect, merge_kwargs, natural_comparison_key
 from ..type import (
@@ -33,6 +33,8 @@ from ..type import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from ..language import DirectiveLocation
 
 __all__ = ["lexicographic_sort_schema"]
@@ -177,14 +179,12 @@ def lexicographic_sort_schema(schema: GraphQLSchema) -> GraphQLSchema:
             sort_directive(directive)
             for directive in sorted(schema.directives, key=sort_by_name_key)
         ],
-        query=cast(
-            "Optional[GraphQLObjectType]", replace_maybe_type(schema.query_type)
-        ),
+        query=cast("GraphQLObjectType | None", replace_maybe_type(schema.query_type)),
         mutation=cast(
-            "Optional[GraphQLObjectType]", replace_maybe_type(schema.mutation_type)
+            "GraphQLObjectType | None", replace_maybe_type(schema.mutation_type)
         ),
         subscription=cast(
-            "Optional[GraphQLObjectType]", replace_maybe_type(schema.subscription_type)
+            "GraphQLObjectType | None", replace_maybe_type(schema.subscription_type)
         ),
         extensions=schema.extensions,
         ast_node=schema.ast_node,

--- a/src/graphql/utilities/print_schema.py
+++ b/src/graphql/utilities/print_schema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from ..language import StringValueNode, print_ast
 from ..language.block_string import is_printable_as_block_string
@@ -31,6 +31,9 @@ from ..type import (
     is_union_type,
 )
 from .ast_from_value import ast_from_value
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 __all__ = [
     "print_directive",

--- a/src/graphql/utilities/separate_operations.py
+++ b/src/graphql/utilities/separate_operations.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, List
+from typing import Any
 
 from ..language import (
     DocumentNode,
@@ -17,13 +17,13 @@ from ..language import (
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ["separate_operations"]
 
 
-DepGraph: TypeAlias = Dict[str, List[str]]
+DepGraph: TypeAlias = dict[str, list[str]]
 
 
 def separate_operations(document_ast: DocumentNode) -> dict[str, DocumentNode]:

--- a/src/graphql/utilities/separate_operations.py
+++ b/src/graphql/utilities/separate_operations.py
@@ -60,7 +60,7 @@ def separate_operations(document_ast: DocumentNode) -> dict[str, DocumentNode]:
         # The list of definition nodes to be included for this operation, sorted
         # to retain the same order as the original document.
         separated_document_asts[operation_name] = DocumentNode(
-            definitions=[
+            definitions=tuple(
                 node
                 for node in document_ast.definitions
                 if node is operation
@@ -68,7 +68,7 @@ def separate_operations(document_ast: DocumentNode) -> dict[str, DocumentNode]:
                     isinstance(node, FragmentDefinitionNode)
                     and node.name.value in dependencies
                 )
-            ]
+            )
         )
 
     return separated_document_asts

--- a/src/graphql/utilities/type_info.py
+++ b/src/graphql/utilities/type_info.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 from ..language import (
     ArgumentNode,
@@ -44,14 +45,14 @@ from .type_from_ast import type_from_ast
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ["TypeInfo", "TypeInfoVisitor"]
 
 
 GetFieldDefFn: TypeAlias = Callable[
-    [GraphQLSchema, GraphQLCompositeType, FieldNode], Optional[GraphQLField]
+    [GraphQLSchema, GraphQLCompositeType, FieldNode], GraphQLField | None
 ]
 
 

--- a/src/graphql/utilities/value_from_ast_untyped.py
+++ b/src/graphql/utilities/value_from_ast_untyped.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from math import nan
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any
 
 from ..pyutils import Undefined, inspect
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..language import (
         BooleanValueNode,
         EnumValueNode,

--- a/src/graphql/validation/rules/defer_stream_directive_label.py
+++ b/src/graphql/validation/rules/defer_stream_directive_label.py
@@ -1,6 +1,6 @@
 """Defer stream directive label rule"""
 
-from typing import Any, Dict, List
+from typing import Any
 
 from ...error import GraphQLError
 from ...language import DirectiveNode, Node, StringValueNode
@@ -19,7 +19,7 @@ class DeferStreamDirectiveLabel(ASTValidationRule):
 
     def __init__(self, context: ValidationContext) -> None:
         super().__init__(context)
-        self.known_labels: Dict[str, Node] = {}
+        self.known_labels: dict[str, Node] = {}
 
     def enter_directive(
         self,
@@ -27,7 +27,7 @@ class DeferStreamDirectiveLabel(ASTValidationRule):
         _key: Any,
         _parent: Any,
         _path: Any,
-        _ancestors: List[Node],
+        _ancestors: list[Node],
     ) -> None:
         if node.name.value not in (
             GraphQLDeferDirective.name,

--- a/src/graphql/validation/rules/executable_definitions.py
+++ b/src/graphql/validation/rules/executable_definitions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Union, cast
+from typing import Any, cast
 
 from ...error import GraphQLError
 from ...language import (
@@ -39,7 +39,7 @@ class ExecutableDefinitionsRule(ASTValidationRule):
                     )
                     else "'{}'".format(
                         cast(
-                            "Union[DirectiveDefinitionNode, TypeDefinitionNode]",
+                            "DirectiveDefinitionNode | TypeDefinitionNode",
                             definition,
                         ).name.value
                     )

--- a/src/graphql/validation/rules/known_argument_names.py
+++ b/src/graphql/validation/rules/known_argument_names.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, cast
+from typing import Any, cast
 
 from ...error import GraphQLError
 from ...language import (
@@ -35,7 +35,7 @@ class KnownArgumentNamesOnDirectivesRule(ASTValidationRule):
 
         schema = context.schema
         defined_directives = schema.directives if schema else specified_directives
-        for directive in cast("List", defined_directives):
+        for directive in cast("list", defined_directives):
             directive_args[directive.name] = list(directive.args)
 
         ast_definitions = context.document.definitions

--- a/src/graphql/validation/rules/known_directives.py
+++ b/src/graphql/validation/rules/known_directives.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, cast
+from typing import Any, cast
 
 from ...error import GraphQLError
 from ...language import (
@@ -35,7 +35,7 @@ class KnownDirectivesRule(ASTValidationRule):
 
         schema = context.schema
         defined_directives = (
-            schema.directives if schema else cast("List", specified_directives)
+            schema.directives if schema else cast("list", specified_directives)
         )
         for directive in defined_directives:
             locations_map[directive.name] = directive.locations

--- a/src/graphql/validation/rules/known_type_names.py
+++ b/src/graphql/validation/rules/known_type_names.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Collection, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ...error import GraphQLError
 from ...language import (
@@ -18,10 +18,13 @@ from ...pyutils import did_you_mean, suggestion_list
 from ...type import introspection_types, specified_scalar_types
 from . import ASTValidationRule, SDLValidationContext, ValidationContext
 
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
 try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 
 __all__ = ["KnownTypeNamesRule"]

--- a/src/graphql/validation/rules/overlapping_fields_can_be_merged.py
+++ b/src/graphql/validation/rules/overlapping_fields_can_be_merged.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import chain
-from typing import Any, Dict, List, Optional, Sequence, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ...error import GraphQLError
 from ...language import (
@@ -32,10 +32,13 @@ from ...utilities import type_from_ast
 from ...utilities.sort_value_node import sort_value_node
 from . import ValidationContext, ValidationRule
 
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = ["OverlappingFieldsCanBeMergedRule"]
@@ -91,15 +94,15 @@ class OverlappingFieldsCanBeMergedRule(ValidationRule):
             )
 
 
-Conflict: TypeAlias = Tuple["ConflictReason", List[FieldNode], List[FieldNode]]
+Conflict: TypeAlias = tuple["ConflictReason", list[FieldNode], list[FieldNode]]
 # Field name and reason.
-ConflictReason: TypeAlias = Tuple[str, "ConflictReasonMessage"]
+ConflictReason: TypeAlias = tuple[str, "ConflictReasonMessage"]
 # Reason is a string, or a nested list of conflicts.
-ConflictReasonMessage: TypeAlias = Union[str, List[ConflictReason]]
+ConflictReasonMessage: TypeAlias = str | list[ConflictReason]
 # Tuple defining a field node in a context.
-NodeAndDef: TypeAlias = Tuple[GraphQLCompositeType, FieldNode, Optional[GraphQLField]]
+NodeAndDef: TypeAlias = tuple[GraphQLCompositeType, FieldNode, GraphQLField | None]
 # Dictionary of lists of those.
-NodeAndDefCollection: TypeAlias = Dict[str, List[NodeAndDef]]
+NodeAndDefCollection: TypeAlias = dict[str, list[NodeAndDef]]
 
 
 # Algorithm:
@@ -538,8 +541,8 @@ def find_conflict(
     )
 
     # The return type for each field.
-    type1 = cast("Optional[GraphQLOutputType]", def1 and def1.type)
-    type2 = cast("Optional[GraphQLOutputType]", def2 and def2.type)
+    type1 = cast("GraphQLOutputType | None", def1 and def1.type)
+    type2 = cast("GraphQLOutputType | None", def2 and def2.type)
 
     if not are_mutually_exclusive:
         # Two aliases must refer to the same field.

--- a/src/graphql/validation/rules/provided_required_arguments.py
+++ b/src/graphql/validation/rules/provided_required_arguments.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, cast
+from typing import Any, cast
 
 from ...error import GraphQLError
 from ...language import (
@@ -41,7 +41,7 @@ class ProvidedRequiredArgumentsOnDirectivesRule(ASTValidationRule):
 
         schema = context.schema
         defined_directives = schema.directives if schema else specified_directives
-        for directive in cast("List", defined_directives):
+        for directive in cast("list", defined_directives):
             required_args_map[directive.name] = {
                 name: arg
                 for name, arg in directive.args.items()

--- a/src/graphql/validation/rules/unique_argument_definition_names.py
+++ b/src/graphql/validation/rules/unique_argument_definition_names.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from operator import attrgetter
-from typing import Any, Collection
+from typing import TYPE_CHECKING, Any
 
 from ...error import GraphQLError
 from ...language import (
@@ -20,6 +20,9 @@ from ...language import (
 )
 from ...pyutils import group_by
 from . import SDLValidationRule
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 __all__ = ["UniqueArgumentDefinitionNamesRule"]
 

--- a/src/graphql/validation/rules/unique_argument_names.py
+++ b/src/graphql/validation/rules/unique_argument_names.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, Collection
+from typing import TYPE_CHECKING, Any
 
 from ...error import GraphQLError
 from ...pyutils import group_by
 from . import ASTValidationRule
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from ...language import ArgumentNode, DirectiveNode, FieldNode
 
 __all__ = ["UniqueArgumentNamesRule"]

--- a/src/graphql/validation/rules/unique_directives_per_location.py
+++ b/src/graphql/validation/rules/unique_directives_per_location.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, List, cast
+from typing import Any, cast
 
 from ...error import GraphQLError
 from ...language import (
@@ -38,7 +38,7 @@ class UniqueDirectivesPerLocationRule(ASTValidationRule):
 
         schema = context.schema
         defined_directives = (
-            schema.directives if schema else cast("List", specified_directives)
+            schema.directives if schema else cast("list", specified_directives)
         )
         for directive in defined_directives:
             unique_directive_map[directive.name] = not directive.is_repeatable
@@ -60,7 +60,7 @@ class UniqueDirectivesPerLocationRule(ASTValidationRule):
         directives = getattr(node, "directives", None)
         if not directives:
             return
-        directives = cast("List[DirectiveNode]", directives)
+        directives = cast("list[DirectiveNode]", directives)
 
         if isinstance(node, (SchemaDefinitionNode, SchemaExtensionNode)):
             seen_directives = self.schema_directives

--- a/src/graphql/validation/rules/values_of_correct_type.py
+++ b/src/graphql/validation/rules/values_of_correct_type.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Mapping, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from ...error import GraphQLError
 from ...language import (
@@ -36,6 +36,9 @@ from ...type import (
     is_required_input_field,
 )
 from . import ValidationContext, ValidationRule
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 __all__ = ["ValuesOfCorrectTypeRule"]
 

--- a/src/graphql/validation/validate.py
+++ b/src/graphql/validation/validate.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection
+from typing import TYPE_CHECKING
 
 from ..error import GraphQLError
 from ..language import DocumentNode, ParallelVisitor, visit
@@ -12,6 +12,8 @@ from .specified_rules import specified_rules, specified_sdl_rules
 from .validation_context import SDLValidationContext, ValidationContext
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from .rules import ASTValidationRule
 
 __all__ = [

--- a/src/graphql/validation/validation_context.py
+++ b/src/graphql/validation/validation_context.py
@@ -5,9 +5,7 @@ from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     NamedTuple,
-    Union,
     cast,
 )
 
@@ -25,6 +23,8 @@ from ..language import (
 from ..utilities import TypeInfo, TypeInfoVisitor
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..error import GraphQLError
     from ..type import (
         GraphQLArgument,
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 __all__ = [
@@ -51,7 +51,7 @@ __all__ = [
     "VariableUsageVisitor",
 ]
 
-NodeWithSelectionSet: TypeAlias = Union[OperationDefinitionNode, FragmentDefinitionNode]
+NodeWithSelectionSet: TypeAlias = OperationDefinitionNode | FragmentDefinitionNode
 
 
 class VariableUsage(NamedTuple):

--- a/tests/benchmarks/test_serialization.py
+++ b/tests/benchmarks/test_serialization.py
@@ -1,0 +1,50 @@
+"""Benchmarks for pickle serialization of parsed queries.
+
+This module benchmarks pickle serialization using a large query (~100KB)
+to provide realistic performance numbers for query caching use cases.
+"""
+
+import pickle
+
+from graphql import parse
+
+from ..fixtures import large_query  # noqa: F401
+
+# Parse benchmark
+
+
+def test_parse_large_query(benchmark, large_query):  # noqa: F811
+    """Benchmark parsing large query."""
+    result = benchmark(lambda: parse(large_query, no_location=True))
+    assert result is not None
+
+
+# Pickle benchmarks
+
+
+def test_pickle_large_query_roundtrip(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle roundtrip for large query AST."""
+    document = parse(large_query, no_location=True)
+
+    def roundtrip():
+        encoded = pickle.dumps(document)
+        return pickle.loads(encoded)
+
+    result = benchmark(roundtrip)
+    assert result == document
+
+
+def test_pickle_large_query_encode(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle encoding for large query AST."""
+    document = parse(large_query, no_location=True)
+    result = benchmark(lambda: pickle.dumps(document))
+    assert isinstance(result, bytes)
+
+
+def test_pickle_large_query_decode(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle decoding for large query AST."""
+    document = parse(large_query, no_location=True)
+    encoded = pickle.dumps(document)
+
+    result = benchmark(lambda: pickle.loads(encoded))
+    assert result == document

--- a/tests/error/test_graphql_error.py
+++ b/tests/error/test_graphql_error.py
@@ -4,7 +4,7 @@ from typing import cast
 
 from graphql.error import GraphQLError
 from graphql.language import (
-    Node,
+    NameNode,
     ObjectTypeDefinitionNode,
     OperationDefinitionNode,
     Source,
@@ -352,7 +352,7 @@ def describe_formatted():
         extensions = {"ext": None}
         error = GraphQLError(
             "test message",
-            Node(),
+            NameNode(value="stub"),
             Source(
                 """
                 query {

--- a/tests/execution/test_customize.py
+++ b/tests/execution/test_customize.py
@@ -8,14 +8,6 @@ from graphql.type import GraphQLField, GraphQLObjectType, GraphQLSchema, GraphQL
 
 pytestmark = pytest.mark.anyio
 
-try:
-    anext  # noqa: B018
-except NameError:  # pragma: no cover (Python < 3.10)
-
-    async def anext(iterator):
-        """Return the next item from an async iterator."""
-        return await iterator.__anext__()
-
 
 def describe_customize_execution():
     def uses_a_custom_field_resolver():

--- a/tests/execution/test_defer.py
+++ b/tests/execution/test_defer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from asyncio import sleep
-from typing import Any, AsyncGenerator, NamedTuple, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 import pytest
 
@@ -30,6 +30,9 @@ from graphql.type import (
     GraphQLSchema,
     GraphQLString,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Awaitable, cast
+from collections.abc import Awaitable
+from typing import Any, cast
 
 import pytest
 

--- a/tests/execution/test_lists.py
+++ b/tests/execution/test_lists.py
@@ -1,4 +1,5 @@
-from typing import Any, AsyncGenerator
+from collections.abc import AsyncGenerator
+from typing import Any
 
 import pytest
 

--- a/tests/execution/test_map_async_iterable.py
+++ b/tests/execution/test_map_async_iterable.py
@@ -5,15 +5,6 @@ from graphql.execution import map_async_iterable
 pytestmark = pytest.mark.anyio
 
 
-try:  # pragma: no cover
-    anext  # noqa: B018
-except NameError:  # pragma: no cover (Python < 3.10)
-
-    async def anext(iterator):
-        """Return the next item from an async iterator."""
-        return await iterator.__anext__()
-
-
 async def double(x: int) -> int:
     """Test callback that doubles the input value."""
     return x + x

--- a/tests/execution/test_middleware.py
+++ b/tests/execution/test_middleware.py
@@ -1,5 +1,6 @@
 import inspect
-from typing import Awaitable, cast
+from collections.abc import Awaitable
+from typing import cast
 
 import pytest
 

--- a/tests/execution/test_mutations.py
+++ b/tests/execution/test_mutations.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from asyncio import sleep
-from typing import Any, Awaitable
+from collections.abc import Awaitable
+from typing import Any
 
 import pytest
 

--- a/tests/execution/test_nonnull.py
+++ b/tests/execution/test_nonnull.py
@@ -1,6 +1,6 @@
 import asyncio
 import re
-from typing import Any, Awaitable, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pytest
 
@@ -16,6 +16,9 @@ from graphql.type import (
     GraphQLString,
 )
 from graphql.utilities import build_schema
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/execution/test_parallel.py
+++ b/tests/execution/test_parallel.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Awaitable
+from collections.abc import Awaitable
 
 import pytest
 

--- a/tests/execution/test_stream.py
+++ b/tests/execution/test_stream.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from asyncio import Event, Lock, gather, sleep
-from typing import Any, Awaitable, NamedTuple
+from collections.abc import Awaitable
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -31,14 +32,6 @@ pytestmark = [
     pytest.mark.filterwarnings("ignore:.* was never awaited:RuntimeWarning"),
     pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning"),
 ]
-
-try:  # pragma: no cover
-    anext  # noqa: B018
-except NameError:  # pragma: no cover (Python < 3.10)
-
-    async def anext(iterator):
-        """Return the next item from an async iterator."""
-        return await iterator.__anext__()
 
 
 friend_type = GraphQLObjectType(

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "cleanup",
     "kitchen_sink_query",
     "kitchen_sink_sdl",
+    "large_query",
 ]
 
 
@@ -54,3 +55,8 @@ def big_schema_sdl():
 @pytest.fixture(scope="module")
 def big_schema_introspection_result():
     return read_json("github_schema")
+
+
+@pytest.fixture(scope="module")
+def large_query():
+    return read_graphql("large_query")

--- a/tests/fixtures/large_query.graphql
+++ b/tests/fixtures/large_query.graphql
@@ -1,0 +1,7006 @@
+# Large query for serialization benchmarks
+query LargeQuery(
+  $orgId: ID!
+  $first: Int!
+  $after: String
+  $includeArchived: Boolean = false
+  $searchTerm: String
+  $sortBy: SortOrder = DESC
+) {
+  viewer {
+    id
+    login
+    name
+    email
+  }
+
+  org0: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members0: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos0: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org1: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members1: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos1: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org2: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members2: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos2: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org3: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members3: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos3: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org4: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members4: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos4: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org5: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members5: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos5: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org6: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members6: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos6: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org7: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members7: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos7: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org8: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members8: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos8: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org9: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members9: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos9: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org10: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members10: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos10: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org11: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members11: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos11: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org12: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members12: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos12: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org13: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members13: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos13: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org14: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members14: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos14: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org15: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members15: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos15: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org16: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members16: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos16: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org17: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members17: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos17: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org18: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members18: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos18: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org19: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members19: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos19: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org20: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members20: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos20: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org21: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members21: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos21: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org22: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members22: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos22: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org23: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members23: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos23: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org24: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members24: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos24: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org25: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members25: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos25: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org26: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members26: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos26: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org27: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members27: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos27: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org28: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members28: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos28: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org29: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members29: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos29: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org30: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members30: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos30: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org31: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members31: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos31: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org32: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members32: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos32: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org33: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members33: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos33: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org34: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members34: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos34: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org35: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members35: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos35: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org36: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members36: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos36: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org37: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members37: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos37: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org38: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members38: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos38: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org39: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members39: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos39: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org40: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members40: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos40: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org41: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members41: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos41: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org42: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members42: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos42: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org43: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members43: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos43: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org44: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members44: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos44: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org45: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members45: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos45: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org46: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members46: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos46: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org47: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members47: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos47: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org48: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members48: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos48: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org49: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members49: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos49: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment UserFragment0 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment0 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment1 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment1 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment2 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment2 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment3 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment3 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment4 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment4 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment5 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment5 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment6 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment6 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment7 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment7 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment8 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment8 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment9 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment9 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment10 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment10 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment11 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment11 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment12 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment12 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment13 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment13 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment14 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment14 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment15 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment15 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment16 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment16 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment17 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment17 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment18 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment18 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment19 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment19 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}

--- a/tests/language/test_ast.py
+++ b/tests/language/test_ast.py
@@ -11,14 +11,21 @@ class SampleTestNode(Node):
     __slots__ = "alpha", "beta"
 
     alpha: int
-    beta: int
+    beta: int | None
 
 
 class SampleNamedNode(Node):
     __slots__ = "foo", "name"
 
     foo: str
-    name: str | None
+    name: NameNode | None
+
+
+def make_loc(start: int = 1, end: int = 3) -> Location:
+    """Create a Location for testing with the given start/end offsets."""
+    source = Source("test source")
+    start_token = Token(TokenKind.NAME, start, end, 1, start, "test")
+    return Location(start_token, start_token, source)
 
 
 def describe_token_class():
@@ -150,43 +157,52 @@ def describe_location_class():
 
 def describe_node_class():
     def initializes_with_keywords():
-        node = SampleTestNode(alpha=1, beta=2, loc=0)
+        node = SampleTestNode(alpha=1, beta=2)
         assert node.alpha == 1
         assert node.beta == 2
-        assert node.loc == 0
-        node = SampleTestNode(alpha=1, loc=None)
+        assert node.loc is None
+
+    def initializes_with_location():
+        loc = make_loc()
+        node = SampleTestNode(alpha=1, beta=2, loc=loc)
+        assert node.alpha == 1
+        assert node.beta == 2
+        assert node.loc is loc
+
+    def initializes_with_none_location():
+        node = SampleTestNode(alpha=1, beta=2, loc=None)
         assert node.loc is None
         assert node.alpha == 1
-        assert node.beta is None
-        node = SampleTestNode(alpha=1, beta=2, gamma=3)
-        assert node.alpha == 1
         assert node.beta == 2
-        assert not hasattr(node, "gamma")
 
     def has_representation_with_loc():
         node = SampleTestNode(alpha=1, beta=2)
         assert repr(node) == "SampleTestNode"
-        node = SampleTestNode(alpha=1, beta=2, loc=3)
-        assert repr(node) == "SampleTestNode at 3"
+        loc = make_loc(start=3, end=5)
+        node = SampleTestNode(alpha=1, beta=2, loc=loc)
+        assert repr(node) == "SampleTestNode at 3:5"
 
     def has_representation_when_named():
         name_node = NameNode(value="baz")
         node = SampleNamedNode(foo="bar", name=name_node)
         assert repr(node) == "SampleNamedNode(name='baz')"
-        node = SampleNamedNode(alpha=1, beta=2, name=name_node, loc=3)
-        assert repr(node) == "SampleNamedNode(name='baz') at 3"
+        loc = make_loc(start=3, end=5)
+        node = SampleNamedNode(foo="bar", name=name_node, loc=loc)
+        assert repr(node) == "SampleNamedNode(name='baz') at 3:5"
 
     def has_representation_when_named_but_name_is_none():
-        node = SampleNamedNode(alpha=1, beta=2, name=None)
+        node = SampleNamedNode(foo="bar", name=None)
         assert repr(node) == "SampleNamedNode"
-        node = SampleNamedNode(alpha=1, beta=2, name=None, loc=3)
-        assert repr(node) == "SampleNamedNode at 3"
+        loc = make_loc(start=3, end=5)
+        node = SampleNamedNode(foo="bar", name=None, loc=loc)
+        assert repr(node) == "SampleNamedNode at 3:5"
 
     def has_special_representation_when_it_is_a_name_node():
         node = NameNode(value="foo")
         assert repr(node) == "NameNode('foo')"
-        node = NameNode(value="foo", loc=3)
-        assert repr(node) == "NameNode('foo') at 3"
+        loc = make_loc(start=3, end=5)
+        node = NameNode(value="foo", loc=loc)
+        assert repr(node) == "NameNode('foo') at 3:5"
 
     def can_check_equality():
         node = SampleTestNode(alpha=1, beta=2)
@@ -195,8 +211,6 @@ def describe_node_class():
         assert node2 == node
         node2 = SampleTestNode(alpha=1, beta=1)
         assert node2 != node
-        node3 = Node(alpha=1, beta=2)
-        assert node3 != node
 
     def can_hash():
         node = SampleTestNode(alpha=1, beta=2)
@@ -208,28 +222,17 @@ def describe_node_class():
         assert node3 != node
         assert hash(node3) != hash(node)
 
-    def caches_are_hashed():
-        node = SampleTestNode(alpha=1)
-        assert not hasattr(node, "_hash")
+    def is_hashable():
+        node = SampleTestNode(alpha=1, beta=2)
         hash1 = hash(node)
-        assert hasattr(node, "_hash")
-        assert hash1 == node._hash  # noqa: SLF001
-        node.alpha = 2
-        assert not hasattr(node, "_hash")
+        # Hash should be stable
         hash2 = hash(node)
-        assert hash2 != hash1
-        assert hasattr(node, "_hash")
-        assert hash2 == node._hash  # noqa: SLF001
+        assert hash1 == hash2
 
     def can_create_weak_reference():
         node = SampleTestNode(alpha=1, beta=2)
         ref = weakref.ref(node)
         assert ref() is node
-
-    def can_create_custom_attribute():
-        node = SampleTestNode(alpha=1, beta=2)
-        node.gamma = 3
-        assert node.gamma == 3  # type: ignore
 
     def can_create_shallow_copy():
         node = SampleTestNode(alpha=1, beta=2)
@@ -238,18 +241,18 @@ def describe_node_class():
         assert node2 == node
 
     def shallow_copy_is_really_shallow():
-        node = SampleTestNode(alpha=1, beta=2)
-        node2 = SampleTestNode(alpha=node, beta=node)
-        node3 = copy(node2)
-        assert node3 is not node2
-        assert node3 == node2
-        assert node3.alpha is node2.alpha
-        assert node3.beta is node2.beta
+        inner = SampleTestNode(alpha=1, beta=2)
+        node = SampleTestNode(alpha=inner, beta=inner)  # type: ignore[arg-type]
+        node2 = copy(node)
+        assert node2 is not node
+        assert node2 == node
+        assert node2.alpha is node.alpha
+        assert node2.beta is node.beta
 
     def can_create_deep_copy():
         alpha = SampleTestNode(alpha=1, beta=2)
         beta = SampleTestNode(alpha=3, beta=4)
-        node = SampleTestNode(alpha=alpha, beta=beta)
+        node = SampleTestNode(alpha=alpha, beta=beta)  # type: ignore[arg-type]
         node2 = deepcopy(node)
         assert node2 is not node
         assert node2 == node
@@ -267,8 +270,9 @@ def describe_node_class():
 
         assert Foo.kind == "foo"
 
-    def provides_keys_as_class_attribute():
-        assert SampleTestNode.keys == ("loc", "alpha", "beta")
+    def provides_keys_as_property():
+        node = SampleTestNode(alpha=1, beta=2)
+        assert node.keys == ("loc", "alpha", "beta")
 
     def can_can_convert_to_dict():
         node = SampleTestNode(alpha=1, beta=2)

--- a/tests/language/test_block_string.py
+++ b/tests/language/test_block_string.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
-from typing import Collection, cast
+from typing import TYPE_CHECKING, cast
 
 from graphql.language.block_string import (
     dedent_block_string_lines,
     is_printable_as_block_string,
     print_block_string,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
 
 
 def join_lines(*args: str) -> str:

--- a/tests/language/test_lexer.py
+++ b/tests/language/test_lexer.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Optional, Tuple
-
 import pytest
 
 from graphql.error import GraphQLSyntaxError
@@ -14,10 +12,10 @@ from ..utils import dedent
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
-Location: TypeAlias = Optional[Tuple[int, int]]
+Location: TypeAlias = tuple[int, int] | None
 
 
 def lex_one(s: str) -> Token:

--- a/tests/language/test_parser.py
+++ b/tests/language/test_parser.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Tuple, cast
+from typing import cast
 
 import pytest
 
@@ -45,10 +45,10 @@ from ..utils import dedent
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
-Location: TypeAlias = Optional[Tuple[int, int]]
+Location: TypeAlias = tuple[int, int] | None
 
 
 def parse_ccn(source: str) -> DocumentNode:

--- a/tests/language/test_predicates.py
+++ b/tests/language/test_predicates.py
@@ -1,5 +1,5 @@
+from collections.abc import Callable
 from operator import attrgetter
-from typing import Callable
 
 from graphql.language import (
     Node,

--- a/tests/language/test_predicates.py
+++ b/tests/language/test_predicates.py
@@ -1,3 +1,4 @@
+import inspect
 from collections.abc import Callable
 from operator import attrgetter
 
@@ -22,7 +23,7 @@ all_ast_nodes = sorted(
     [
         node_type()
         for node_type in vars(ast).values()
-        if type(node_type) is type
+        if inspect.isclass(node_type)
         and issubclass(node_type, Node)
         and not node_type.__name__.startswith("Const")
     ],
@@ -36,13 +37,12 @@ def filter_nodes(predicate: Callable[[Node], bool]):
 
 def describe_ast_node_predicates():
     def check_definition_node():
+        # With flattened hierarchy, only concrete definition nodes are matched
         assert filter_nodes(is_definition_node) == [
-            "definition",
             "directive_definition",
             "enum_type_definition",
             "enum_type_extension",
             "enum_value_definition",
-            "executable_definition",
             "field_definition",
             "fragment_definition",
             "input_object_type_definition",
@@ -56,16 +56,13 @@ def describe_ast_node_predicates():
             "scalar_type_definition",
             "scalar_type_extension",
             "schema_definition",
-            "type_definition",
-            "type_extension",
-            "type_system_definition",
+            "schema_extension",
             "union_type_definition",
             "union_type_extension",
         ]
 
     def check_executable_definition_node():
         assert filter_nodes(is_executable_definition_node) == [
-            "executable_definition",
             "fragment_definition",
             "operation_definition",
         ]
@@ -75,7 +72,6 @@ def describe_ast_node_predicates():
             "field",
             "fragment_spread",
             "inline_fragment",
-            "selection",
         ]
 
     def check_nullability_assertion_node():
@@ -83,7 +79,6 @@ def describe_ast_node_predicates():
             "error_boundary",
             "list_nullability_operator",
             "non_null_assertion",
-            "nullability_assertion",
         ]
 
     def check_value_node():
@@ -96,7 +91,6 @@ def describe_ast_node_predicates():
             "null_value",
             "object_value",
             "string_value",
-            "value",
             "variable",
         ]
 
@@ -115,28 +109,18 @@ def describe_ast_node_predicates():
             "list_type",
             "named_type",
             "non_null_type",
-            "type",
         ]
 
     def check_type_system_definition_node():
         assert filter_nodes(is_type_system_definition_node) == [
             "directive_definition",
             "enum_type_definition",
-            "enum_type_extension",
             "input_object_type_definition",
-            "input_object_type_extension",
             "interface_type_definition",
-            "interface_type_extension",
             "object_type_definition",
-            "object_type_extension",
             "scalar_type_definition",
-            "scalar_type_extension",
             "schema_definition",
-            "type_definition",
-            "type_extension",
-            "type_system_definition",
             "union_type_definition",
-            "union_type_extension",
         ]
 
     def check_type_definition_node():
@@ -146,7 +130,6 @@ def describe_ast_node_predicates():
             "interface_type_definition",
             "object_type_definition",
             "scalar_type_definition",
-            "type_definition",
             "union_type_definition",
         ]
 
@@ -158,7 +141,6 @@ def describe_ast_node_predicates():
             "object_type_extension",
             "scalar_type_extension",
             "schema_extension",
-            "type_extension",
             "union_type_extension",
         ]
 
@@ -169,6 +151,5 @@ def describe_ast_node_predicates():
             "interface_type_extension",
             "object_type_extension",
             "scalar_type_extension",
-            "type_extension",
             "union_type_extension",
         ]

--- a/tests/language/test_schema_parser.py
+++ b/tests/language/test_schema_parser.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import pickle
 from copy import deepcopy
 from textwrap import dedent
-from typing import Optional, Tuple
 
 import pytest
 
@@ -44,10 +43,10 @@ from ..fixtures import kitchen_sink_sdl  # noqa: F401
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
-Location: TypeAlias = Optional[Tuple[int, int]]
+Location: TypeAlias = tuple[int, int] | None
 
 
 def assert_syntax_error(text: str, message: str, location: Location) -> None:

--- a/tests/language/test_schema_parser.py
+++ b/tests/language/test_schema_parser.py
@@ -78,12 +78,12 @@ def name_node(name: str, loc: Location):
 
 
 def field_node(name: NameNode, type_: TypeNode, loc: Location):
-    return field_node_with_args(name, type_, [], loc)
+    return field_node_with_args(name, type_, (), loc)
 
 
-def field_node_with_args(name: NameNode, type_: TypeNode, args: list, loc: Location):
+def field_node_with_args(name: NameNode, type_: TypeNode, args: tuple, loc: Location):
     return FieldDefinitionNode(
-        name=name, arguments=args, type=type_, directives=[], loc=loc, description=None
+        name=name, arguments=args, type=type_, directives=(), loc=loc, description=None
     )
 
 
@@ -93,7 +93,7 @@ def non_null_type(type_: TypeNode, loc: Location):
 
 def enum_value_node(name: str, loc: Location):
     return EnumValueDefinitionNode(
-        name=name_node(name, loc), directives=[], loc=loc, description=None
+        name=name_node(name, loc), directives=(), loc=loc, description=None
     )
 
 
@@ -104,7 +104,7 @@ def input_value_node(
         name=name,
         type=type_,
         default_value=default_value,
-        directives=[],
+        directives=(),
         loc=loc,
         description=None,
     )
@@ -123,8 +123,8 @@ def list_type_node(type_: TypeNode, loc: Location):
 
 
 def schema_extension_node(
-    directives: list[DirectiveNode],
-    operation_types: list[OperationTypeDefinitionNode],
+    directives: tuple[DirectiveNode, ...],
+    operation_types: tuple[OperationTypeDefinitionNode, ...],
     loc: Location,
 ):
     return SchemaExtensionNode(
@@ -136,7 +136,7 @@ def operation_type_definition(operation: OperationType, type_: TypeNode, loc: Lo
     return OperationTypeDefinitionNode(operation=operation, type=type_, loc=loc)
 
 
-def directive_node(name: NameNode, arguments: list[ArgumentNode], loc: Location):
+def directive_node(name: NameNode, arguments: tuple[ArgumentNode, ...], loc: Location):
     return DirectiveNode(name=name, arguments=arguments, loc=loc)
 
 
@@ -351,14 +351,14 @@ def describe_schema_parser():
         assert doc.loc == (0, 75)
         assert doc.definitions == (
             schema_extension_node(
-                [],
-                [
+                (),
+                (
                     operation_type_definition(
                         OperationType.MUTATION,
                         type_node("Mutation", (53, 61)),
                         (43, 61),
-                    )
-                ],
+                    ),
+                ),
                 (13, 75),
             ),
         )
@@ -370,8 +370,8 @@ def describe_schema_parser():
         assert doc.loc == (0, 24)
         assert doc.definitions == (
             schema_extension_node(
-                [directive_node(name_node("directive", (15, 24)), [], (14, 24))],
-                [],
+                (directive_node(name_node("directive", (15, 24)), (), (14, 24)),),
+                (),
                 (0, 24),
             ),
         )
@@ -571,14 +571,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (38, 44)),
-                [
+                (
                     input_value_node(
                         name_node("flag", (22, 26)),
                         type_node("Boolean", (28, 35)),
                         None,
                         (22, 35),
-                    )
-                ],
+                    ),
+                ),
                 (16, 44),
             ),
         )
@@ -602,14 +602,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (45, 51)),
-                [
+                (
                     input_value_node(
                         name_node("flag", (22, 26)),
                         type_node("Boolean", (28, 35)),
                         boolean_value_node(True, (38, 42)),
                         (22, 42),
-                    )
-                ],
+                    ),
+                ),
                 (16, 51),
             ),
         )
@@ -633,14 +633,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (41, 47)),
-                [
+                (
                     input_value_node(
                         name_node("things", (22, 28)),
                         list_type_node(type_node("String", (31, 37)), (30, 38)),
                         None,
                         (22, 38),
-                    )
-                ],
+                    ),
+                ),
                 (16, 47),
             ),
         )
@@ -664,7 +664,7 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (53, 59)),
-                [
+                (
                     input_value_node(
                         name_node("argOne", (22, 28)),
                         type_node("Boolean", (30, 37)),
@@ -677,7 +677,7 @@ def describe_schema_parser():
                         None,
                         (39, 50),
                     ),
-                ],
+                ),
                 (16, 59),
             ),
         )

--- a/tests/language/test_visitor.py
+++ b/tests/language/test_visitor.py
@@ -595,11 +595,11 @@ def describe_visitor():
 
         # Note: CustomFieldNode subclasses Node directly since
         # SelectionNode is a type alias (union), not a class.
-        class CustomFieldNode(Node):
-            __slots__ = "name", "selection_set"
-
-            name: NameNode
-            selection_set: SelectionSetNode | None
+        # With msgspec.Struct, we use frozen=True, kw_only=True syntax.
+        # Fields are nullable for minimal test fixtures.
+        class CustomFieldNode(Node, frozen=True, kw_only=True):
+            name: NameNode | None = None
+            selection_set: SelectionSetNode | None = None
 
         # Build custom AST immutably
         op_def = cast("OperationDefinitionNode", parsed_ast.definitions[0])

--- a/tests/language/test_visitor.py
+++ b/tests/language/test_visitor.py
@@ -14,7 +14,6 @@ from graphql.language import (
     NameNode,
     Node,
     ParallelVisitor,
-    SelectionNode,
     SelectionSetNode,
     Visitor,
     VisitorKeyMap,
@@ -573,7 +572,9 @@ def describe_visitor():
         # so we keep allowing this and test this feature here.
         custom_ast = parse("{ a }")
 
-        class CustomFieldNode(SelectionNode):
+        # Note: CustomFieldNode now subclasses Node directly since
+        # SelectionNode is a type alias (union), not a class.
+        class CustomFieldNode(Node):
             __slots__ = "name", "selection_set"
 
             name: NameNode

--- a/tests/language/test_visitor.py
+++ b/tests/language/test_visitor.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from copy import copy
 from functools import partial
 from typing import Any, cast
 
@@ -10,9 +9,11 @@ from graphql.language import (
     BREAK,
     REMOVE,
     SKIP,
+    DocumentNode,
     FieldNode,
     NameNode,
     Node,
+    OperationDefinitionNode,
     ParallelVisitor,
     SelectionSetNode,
     Visitor,
@@ -310,20 +311,34 @@ def describe_visitor():
 
             def enter_operation_definition(self, *args):
                 check_visitor_fn_args(ast, *args)
-                node = copy(args[0])
+                node = args[0]
                 assert len(node.selection_set.selections) == 3
                 self.selection_set = node.selection_set
-                node.selection_set = SelectionSetNode(selections=[])
+                # Create new node with empty selection set (immutable pattern)
+                new_node = OperationDefinitionNode(
+                    operation=node.operation,
+                    name=node.name,
+                    variable_definitions=node.variable_definitions,
+                    directives=node.directives,
+                    selection_set=SelectionSetNode(selections=()),
+                )
                 visited.append("enter")
-                return node
+                return new_node
 
             def leave_operation_definition(self, *args):
                 check_visitor_fn_args_edited(ast, *args)
-                node = copy(args[0])
+                node = args[0]
                 assert not node.selection_set.selections
-                node.selection_set = self.selection_set
+                # Create new node with original selection set (immutable pattern)
+                new_node = OperationDefinitionNode(
+                    operation=node.operation,
+                    name=node.name,
+                    variable_definitions=node.variable_definitions,
+                    directives=node.directives,
+                    selection_set=self.selection_set,
+                )
                 visited.append("leave")
-                return node
+                return new_node
 
         edited_ast = visit(ast, TestVisitor())
         assert edited_ast == ast
@@ -390,13 +405,19 @@ def describe_visitor():
                 check_visitor_fn_args_edited(ast, *args)
                 node = args[0]
                 if isinstance(node, FieldNode) and node.name.value == "a":
-                    node = copy(node)
                     assert node.selection_set
-                    node.selection_set.selections = (
-                        added_field,
-                        *node.selection_set.selections,
+                    # Create new selection set with added field (immutable pattern)
+                    new_selection_set = SelectionSetNode(
+                        selections=(added_field, *node.selection_set.selections)
                     )
-                    return node
+                    return FieldNode(
+                        alias=node.alias,
+                        name=node.name,
+                        arguments=node.arguments,
+                        directives=node.directives,
+                        nullability_assertion=node.nullability_assertion,
+                        selection_set=new_selection_set,
+                    )
                 if node == added_field:
                     self.did_visit_added_field = True
                 return None
@@ -570,9 +591,9 @@ def describe_visitor():
         # GraphQL.js removed support for unknown node types,
         # but it is easy for us to add and support custom node types,
         # so we keep allowing this and test this feature here.
-        custom_ast = parse("{ a }")
+        parsed_ast = parse("{ a }")
 
-        # Note: CustomFieldNode now subclasses Node directly since
+        # Note: CustomFieldNode subclasses Node directly since
         # SelectionNode is a type alias (union), not a class.
         class CustomFieldNode(Node):
             __slots__ = "name", "selection_set"
@@ -580,21 +601,33 @@ def describe_visitor():
             name: NameNode
             selection_set: SelectionSetNode | None
 
-        custom_selection_set = cast(
-            "FieldNode", custom_ast.definitions[0]
-        ).selection_set
-        assert custom_selection_set is not None
-        custom_selection_set.selections = (
-            *custom_selection_set.selections,
-            CustomFieldNode(
-                name=NameNode(value="NameNodeToBeSkipped"),
-                selection_set=SelectionSetNode(
-                    selections=CustomFieldNode(
-                        name=NameNode(value="NameNodeToBeSkipped")
-                    )
-                ),
+        # Build custom AST immutably
+        op_def = cast("OperationDefinitionNode", parsed_ast.definitions[0])
+        assert op_def.selection_set is not None
+        original_selection_set = op_def.selection_set
+
+        # Create custom field with nested selection
+        custom_field = CustomFieldNode(
+            name=NameNode(value="NameNodeToBeSkipped"),
+            selection_set=SelectionSetNode(
+                selections=(
+                    CustomFieldNode(name=NameNode(value="NameNodeToBeSkipped")),
+                )
             ),
         )
+
+        # Build new nodes immutably (copy-on-write pattern)
+        new_selection_set = SelectionSetNode(
+            selections=(*original_selection_set.selections, custom_field)
+        )
+        new_op_def = OperationDefinitionNode(
+            operation=op_def.operation,
+            name=op_def.name,
+            variable_definitions=op_def.variable_definitions,
+            directives=op_def.directives,
+            selection_set=new_selection_set,
+        )
+        custom_ast = DocumentNode(definitions=(new_op_def,))
 
         visited = []
 

--- a/tests/pyutils/test_gather_with_cancel.py
+++ b/tests/pyutils/test_gather_with_cancel.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from asyncio import Event, create_task, gather, sleep, wait_for
-from typing import Callable
+from typing import TYPE_CHECKING
 
 import pytest
 
 from graphql.pyutils import gather_with_cancel, is_awaitable
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 pytestmark = pytest.mark.anyio
 

--- a/tests/pyutils/test_inspect.py
+++ b/tests/pyutils/test_inspect.py
@@ -233,7 +233,7 @@ def describe_inspect():
         assert inspect({"a": True, "b": None}) == "{'a': True, 'b': None}"
 
     def inspect_overly_large_dict():
-        s = dict(zip((chr(97 + i) for i in range(20)), range(20)))
+        s = dict(zip((chr(97 + i) for i in range(20)), range(20), strict=False))
         assert (
             inspect(s) == "{'a': 0, 'b': 1, 'c': 2, 'd': 3, 'e': 4,"
             " ..., 'q': 16, 'r': 17, 's': 18, 't': 19}"

--- a/tests/star_wars_data.py
+++ b/tests/star_wars_data.py
@@ -7,7 +7,10 @@ demo.
 
 from __future__ import annotations
 
-from typing import Awaitable, Collection, Iterator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Collection, Iterator
 
 __all__ = ["get_droid", "get_friends", "get_hero", "get_human", "get_secret_backstory"]
 

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -3,17 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from .utils import dedent
 
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
-Scope: TypeAlias = Dict[str, Any]
+Scope: TypeAlias = dict[str, Any]
 
 
 def get_snippets(source, indent=4):

--- a/tests/test_user_registry.py
+++ b/tests/test_user_registry.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 from asyncio import create_task, sleep, wait
 from collections import defaultdict
+from collections.abc import AsyncIterable
 from enum import Enum
-from typing import Any, AsyncIterable, NamedTuple
+from typing import Any, NamedTuple
 
 import pytest
 

--- a/tests/type/test_definition.py
+++ b/tests/type/test_definition.py
@@ -4,7 +4,7 @@ import pickle
 import sys
 from enum import Enum
 from math import isnan, nan
-from typing import Any, Awaitable, Callable
+from typing import TYPE_CHECKING, Any
 
 try:
     from typing import TypedDict
@@ -58,10 +58,13 @@ from graphql.type import (
     introspection_types,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
 try:
     from typing import TypeGuard
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeGuard
+    from typing import TypeGuard
 
 ScalarType = GraphQLScalarType("Scalar")
 ObjectType = GraphQLObjectType("Object", {})

--- a/tests/type/test_directives.py
+++ b/tests/type/test_directives.py
@@ -1,14 +1,18 @@
 import pytest
 
 from graphql.error import GraphQLError
-from graphql.language import DirectiveDefinitionNode, DirectiveLocation
+from graphql.language import DirectiveDefinitionNode, DirectiveLocation, NameNode
 from graphql.type import GraphQLArgument, GraphQLDirective, GraphQLInt, GraphQLString
 
 
 def describe_type_system_directive():
     def can_create_instance():
         arg = GraphQLArgument(GraphQLString, description="arg description")
-        node = DirectiveDefinitionNode()
+        node = DirectiveDefinitionNode(
+            name=NameNode(value="test"),
+            repeatable=False,
+            locations=(),
+        )
         locations = [DirectiveLocation.SCHEMA, DirectiveLocation.OBJECT]
         directive = GraphQLDirective(
             name="test",

--- a/tests/type/test_schema.py
+++ b/tests/type/test_schema.py
@@ -35,6 +35,14 @@ from graphql.utilities import build_schema, lexicographic_sort_schema, print_sch
 from ..utils import dedent
 
 
+def _stub_schema_def() -> SchemaDefinitionNode:
+    return SchemaDefinitionNode(operation_types=())
+
+
+def _stub_schema_ext() -> SchemaExtensionNode:
+    return SchemaExtensionNode()
+
+
 def describe_type_system_schema():
     def define_sample_schema():
         BlogImage = GraphQLObjectType(
@@ -425,8 +433,8 @@ def describe_type_system_schema():
 
     def describe_ast_nodes():
         def accepts_a_scalar_type_with_ast_node_and_extension_ast_nodes():
-            ast_node = SchemaDefinitionNode()
-            extension_ast_nodes = [SchemaExtensionNode()]
+            ast_node = _stub_schema_def()
+            extension_ast_nodes = [_stub_schema_ext()]
             schema = GraphQLSchema(
                 GraphQLObjectType("Query", {}),
                 ast_node=ast_node,

--- a/tests/utilities/test_ast_from_value.py
+++ b/tests/utilities/test_ast_from_value.py
@@ -204,13 +204,13 @@ def describe_ast_from_value():
         assert ast_from_value(
             ["FOO", "BAR"], GraphQLList(GraphQLString)
         ) == ConstListValueNode(
-            values=[StringValueNode(value="FOO"), StringValueNode(value="BAR")]
+            values=(StringValueNode(value="FOO"), StringValueNode(value="BAR"))
         )
 
         assert ast_from_value(
             ["HELLO", "GOODBYE"], GraphQLList(my_enum)
         ) == ConstListValueNode(
-            values=[EnumValueNode(value="HELLO"), EnumValueNode(value="GOODBYE")]
+            values=(EnumValueNode(value="HELLO"), EnumValueNode(value="GOODBYE"))
         )
 
         def list_generator():
@@ -220,11 +220,11 @@ def describe_ast_from_value():
 
         assert ast_from_value(list_generator(), GraphQLList(GraphQLInt)) == (
             ConstListValueNode(
-                values=[
+                values=(
                     IntValueNode(value="1"),
                     IntValueNode(value="2"),
                     IntValueNode(value="3"),
-                ]
+                )
             )
         )
 
@@ -239,7 +239,7 @@ def describe_ast_from_value():
         )
 
         assert ast == ConstListValueNode(
-            values=[StringValueNode(value="FOO"), StringValueNode(value="BAR")]
+            values=(StringValueNode(value="FOO"), StringValueNode(value="BAR"))
         )
 
     input_obj = GraphQLInputObjectType(
@@ -251,21 +251,21 @@ def describe_ast_from_value():
         assert ast_from_value(
             {"foo": 3, "bar": "HELLO"}, input_obj
         ) == ConstObjectValueNode(
-            fields=[
+            fields=(
                 ConstObjectFieldNode(
                     name=NameNode(value="foo"), value=FloatValueNode(value="3")
                 ),
                 ConstObjectFieldNode(
                     name=NameNode(value="bar"), value=EnumValueNode(value="HELLO")
                 ),
-            ]
+            )
         )
 
     def converts_input_objects_with_explicit_nulls():
         assert ast_from_value({"foo": None}, input_obj) == ConstObjectValueNode(
-            fields=[
-                ConstObjectFieldNode(name=NameNode(value="foo"), value=NullValueNode())
-            ]
+            fields=(
+                ConstObjectFieldNode(name=NameNode(value="foo"), value=NullValueNode()),
+            )
         )
 
     def does_not_convert_non_object_values_as_input_objects():

--- a/tests/utilities/test_build_ast_schema.py
+++ b/tests/utilities/test_build_ast_schema.py
@@ -133,7 +133,7 @@ def describe_schema_builder():
 
     def match_order_of_default_types_and_directives():
         schema = GraphQLSchema()
-        sdl_schema = build_ast_schema(DocumentNode(definitions=[]))
+        sdl_schema = build_ast_schema(DocumentNode(definitions=()))
 
         assert sdl_schema.directives == schema.directives
         assert sdl_schema.type_map == schema.type_map

--- a/tests/utilities/test_build_ast_schema.py
+++ b/tests/utilities/test_build_ast_schema.py
@@ -4,7 +4,6 @@ import pickle
 import sys
 from collections import namedtuple
 from copy import deepcopy
-from typing import Union
 
 import pytest
 
@@ -47,7 +46,7 @@ from ..utils import dedent, viral_sdl
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
 def cycle_sdl(sdl: str) -> str:
@@ -62,9 +61,13 @@ def cycle_sdl(sdl: str) -> str:
     return print_schema(schema)
 
 
-TypeWithAstNode: TypeAlias = Union[
-    GraphQLArgument, GraphQLEnumValue, GraphQLField, GraphQLInputField, GraphQLNamedType
-]
+TypeWithAstNode: TypeAlias = (
+    GraphQLArgument
+    | GraphQLEnumValue
+    | GraphQLField
+    | GraphQLInputField
+    | GraphQLNamedType
+)
 
 TypeWithExtensionAstNodes: TypeAlias = GraphQLNamedType
 

--- a/tests/utilities/test_extend_schema.py
+++ b/tests/utilities/test_extend_schema.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Union
-
 import pytest
 
 from graphql import graphql_sync
@@ -35,22 +33,19 @@ from ..utils import dedent
 try:
     from typing import TypeAlias
 except ImportError:  # Python < 3.10
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 
-TypeWithAstNode: TypeAlias = Union[
-    GraphQLArgument,
-    GraphQLEnumValue,
-    GraphQLField,
-    GraphQLInputField,
-    GraphQLNamedType,
-    GraphQLSchema,
-]
+TypeWithAstNode: TypeAlias = (
+    GraphQLArgument
+    | GraphQLEnumValue
+    | GraphQLField
+    | GraphQLInputField
+    | GraphQLNamedType
+    | GraphQLSchema
+)
 
-TypeWithExtensionAstNodes: TypeAlias = Union[
-    GraphQLNamedType,
-    GraphQLSchema,
-]
+TypeWithExtensionAstNodes: TypeAlias = GraphQLNamedType | GraphQLSchema
 
 
 def expect_extension_ast_nodes(obj: TypeWithExtensionAstNodes, expected: str) -> None:

--- a/tests/utilities/test_get_introspection_query.py
+++ b/tests/utilities/test_get_introspection_query.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Pattern
+from re import Pattern
 
 from graphql.language import parse
 from graphql.utilities import build_schema, get_introspection_query

--- a/tests/utilities/test_print_schema.py
+++ b/tests/utilities/test_print_schema.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, cast
+from typing import Any, cast
 
 from graphql.language import DirectiveLocation
 from graphql.type import (
@@ -571,7 +571,7 @@ def describe_type_system_printer():
     def prints_empty_types():
         schema = GraphQLSchema(
             types=[
-                GraphQLEnumType("SomeEnum", cast("Dict[str, Any]", {})),
+                GraphQLEnumType("SomeEnum", cast("dict[str, Any]", {})),
                 GraphQLInputObjectType("SomeInputObject", {}),
                 GraphQLInterfaceType("SomeInterface", {}),
                 GraphQLObjectType("SomeObject", {}),

--- a/tests/utilities/test_type_from_ast.py
+++ b/tests/utilities/test_type_from_ast.py
@@ -1,6 +1,5 @@
-import pytest
 
-from graphql.language import TypeNode, parse_type
+from graphql.language import parse_type
 from graphql.type import GraphQLList, GraphQLNonNull, GraphQLObjectType
 from graphql.utilities import type_from_ast
 
@@ -30,9 +29,6 @@ def describe_type_from_ast():
         assert isinstance(of_type, GraphQLObjectType)
         assert of_type.name == "Cat"
 
-    def for_unspecified_type_node():
-        node = TypeNode()
-        with pytest.raises(TypeError) as exc_info:
-            type_from_ast(test_schema, node)
-        msg = str(exc_info.value)
-        assert msg == "Unexpected type node: <TypeNode instance>."
+    # Note: for_unspecified_type_node test removed because TypeNode is now
+    # a type alias (union) and cannot be instantiated. The type system now
+    # enforces that only concrete type nodes can be created.

--- a/tests/utilities/test_type_info.py
+++ b/tests/utilities/test_type_info.py
@@ -346,7 +346,7 @@ def describe_visit_with_type_info():
                         arguments=node.arguments,
                         directives=node.directives,
                         selection_set=SelectionSetNode(
-                            selections=[FieldNode(name=NameNode(value="__typename"))]
+                            selections=(FieldNode(name=NameNode(value="__typename")),)
                         ),
                     )
 

--- a/tests/utils/assert_equal_awaitables_or_values.py
+++ b/tests/utils/assert_equal_awaitables_or_values.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Awaitable, Tuple, TypeVar, cast
+from typing import TYPE_CHECKING, TypeVar, cast
 
 from graphql.pyutils import is_awaitable
 
 from .assert_matching_values import assert_matching_values
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable
 
 __all__ = ["assert_equal_awaitables_or_values"]
 
@@ -15,7 +18,7 @@ T = TypeVar("T")
 def assert_equal_awaitables_or_values(*items: T) -> T:
     """Check whether the items are the same and either all awaitables or all values."""
     if all(is_awaitable(item) for item in items):
-        awaitable_items = cast("Tuple[Awaitable]", items)
+        awaitable_items = cast("tuple[Awaitable]", items)
 
         async def assert_matching_awaitables():
             return assert_matching_values(*(await asyncio.gather(*awaitable_items)))

--- a/tests/utils/gen_fuzz_strings.py
+++ b/tests/utils/gen_fuzz_strings.py
@@ -1,5 +1,5 @@
+from collections.abc import Generator
 from itertools import product
-from typing import Generator
 
 __all__ = ["gen_fuzz_strings"]
 

--- a/tests/validation/test_no_deprecated.py
+++ b/tests/validation/test_no_deprecated.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Callable
+from typing import TYPE_CHECKING
 
 from graphql.utilities import build_schema
 from graphql.validation import NoDeprecatedCustomRule
 
 from .harness import assert_validation_errors
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def build_assertions(


### PR DESCRIPTION
Hello @Cito,

We make use of GraphQL-core (via graphene as our definition layer) at Nextdoor, and a core bottleneck for us is that query parsing is slow, and query serialization/deserializationperformance is even slower than parsing which makes caching remote-caching the queries using pickle provide no advantage (this changes dependent on python version and serialization protocol).

I spent some time over the holidays profiling and working on performance improvements and would like to get your input. 

I have a proposal for a series of changes, which I have made as a series of logically independent commits with a goal of providing the ability to serialize a query using Messagepack via the msgspec library, which provides highly optimized serialization as well as struct-like objects. This new serialization is exposed on the DocumentNode as: `to_bytes_unstable(self) -> bytes` and `from_bytes_unstable(cls, data: bytes) -> DocumentNode` to indicate the evolving nature, and potential for version incompatibility.  I can plan to break this up into a series of PRS so the are easier to review and merge independently, but right now they are structured as commits with the goal that each commit can be landed individually (and should pass all tests etc).

**Downsides**:
Msgspec does not support PyPy, so we'd need to either drop support for PyPy, or I can work on providing the msgspec variant as an extras. I believe it should be possible to support both simultaneously without duplication. 

**Alternatives**
We can get material gains by converting to Dataclasses (mostly due to slowness in our current setattr). We could then conditionally make use of msgspec structs if the library is available. 
Additionally and separately, we can make parsing roughly twice as fast by compiling a mypyc extension due to the overhead of function calls in parsing loops. We could build a wheel such that this is only used for non pypy users. As future work, Using Mypyc is likely a big lever for speeding up the query execution codepaths. 


I plan to run this fork in production at Nextdoor to verify these changes have the impact level I expect with our specific workload, but based upon introduced performance tests, the current results are substantial:

General performance: (requires only the classes use msgspec.Structs, no reliance on serialization protocol)
```
Performance improvement on large query (~117KB):
- Parse:         15.4ms (was 81ms, 5.3x faster)
- Pickle encode:  5.2ms (was 24ms, 4.6x faster)
- Pickle decode:  7.5ms (was 42ms, 5.6x faster)
```

With the final addition of msgpack serialization protocol.

```
Serialization Performance on large query (~117KB, no locations):
  Msgpack Size:        124KB vs 383KB pickle (3.1x smaller)
  Msgpack Serialize:   0.4ms vs 5.2ms pickle (13x faster)
  Msgpack Deserialize: 1.6ms vs 7.5ms pickle (4.7x faster)

Performance vs parsing:
  Msgpack Deserialize: 1.6ms vs 15.4ms parse (10x faster)
```