### PR TITLE
1: Add Serialization Benchmark

### DIFF
--- a/tests/benchmarks/test_serialization.py
+++ b/tests/benchmarks/test_serialization.py
@@ -1,0 +1,50 @@
+"""Benchmarks for pickle serialization of parsed queries.
+
+This module benchmarks pickle serialization using a large query (~100KB)
+to provide realistic performance numbers for query caching use cases.
+"""
+
+import pickle
+
+from graphql import parse
+
+from ..fixtures import large_query  # noqa: F401
+
+# Parse benchmark
+
+
+def test_parse_large_query(benchmark, large_query):  # noqa: F811
+    """Benchmark parsing large query."""
+    result = benchmark(lambda: parse(large_query, no_location=True))
+    assert result is not None
+
+
+# Pickle benchmarks
+
+
+def test_pickle_large_query_roundtrip(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle roundtrip for large query AST."""
+    document = parse(large_query, no_location=True)
+
+    def roundtrip():
+        encoded = pickle.dumps(document)
+        return pickle.loads(encoded)
+
+    result = benchmark(roundtrip)
+    assert result == document
+
+
+def test_pickle_large_query_encode(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle encoding for large query AST."""
+    document = parse(large_query, no_location=True)
+    result = benchmark(lambda: pickle.dumps(document))
+    assert isinstance(result, bytes)
+
+
+def test_pickle_large_query_decode(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle decoding for large query AST."""
+    document = parse(large_query, no_location=True)
+    encoded = pickle.dumps(document)
+
+    result = benchmark(lambda: pickle.loads(encoded))
+    assert result == document

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "cleanup",
     "kitchen_sink_query",
     "kitchen_sink_sdl",
+    "large_query",
 ]
 
 
@@ -54,3 +55,8 @@ def big_schema_sdl():
 @pytest.fixture(scope="module")
 def big_schema_introspection_result():
     return read_json("github_schema")
+
+
+@pytest.fixture(scope="module")
+def large_query():
+    return read_graphql("large_query")

--- a/tests/fixtures/large_query.graphql
+++ b/tests/fixtures/large_query.graphql
@@ -1,0 +1,7006 @@
+# Large query for serialization benchmarks
+query LargeQuery(
+  $orgId: ID!
+  $first: Int!
+  $after: String
+  $includeArchived: Boolean = false
+  $searchTerm: String
+  $sortBy: SortOrder = DESC
+) {
+  viewer {
+    id
+    login
+    name
+    email
+  }
+
+  org0: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members0: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos0: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org1: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members1: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos1: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org2: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members2: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos2: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org3: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members3: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos3: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org4: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members4: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos4: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org5: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members5: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos5: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org6: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members6: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos6: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org7: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members7: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos7: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org8: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members8: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos8: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org9: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members9: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos9: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org10: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members10: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos10: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org11: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members11: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos11: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org12: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members12: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos12: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org13: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members13: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos13: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org14: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members14: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos14: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org15: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members15: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos15: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org16: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members16: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos16: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org17: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members17: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos17: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org18: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members18: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos18: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org19: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members19: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos19: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org20: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members20: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos20: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org21: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members21: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos21: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org22: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members22: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos22: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org23: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members23: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos23: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org24: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members24: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos24: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org25: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members25: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos25: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org26: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members26: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos26: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org27: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members27: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos27: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org28: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members28: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos28: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org29: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members29: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos29: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org30: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members30: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos30: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org31: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members31: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos31: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org32: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members32: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos32: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org33: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members33: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos33: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org34: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members34: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos34: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org35: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members35: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos35: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org36: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members36: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos36: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org37: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members37: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos37: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org38: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members38: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos38: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org39: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members39: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos39: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org40: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members40: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos40: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org41: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members41: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos41: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org42: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members42: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos42: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org43: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members43: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos43: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org44: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members44: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos44: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org45: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members45: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos45: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org46: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members46: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos46: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org47: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members47: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos47: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org48: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members48: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos48: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org49: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members49: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos49: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment UserFragment0 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment0 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment1 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment1 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment2 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment2 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment3 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment3 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment4 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment4 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment5 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment5 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment6 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment6 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment7 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment7 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment8 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment8 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment9 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment9 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment10 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment10 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment11 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment11 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment12 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment12 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment13 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment13 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment14 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment14 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment15 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment15 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment16 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment16 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment17 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment17 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment18 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment18 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment19 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment19 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}


### PR DESCRIPTION
Introduce benchmarks using a large (~117KB) GraphQL query to measure parse and pickle serialization performance. These provide a baseline for comparing serialization approaches in subsequent commits.

Baseline performance (measrued on a Macbook Pro M4 Max):
- Parse:         81ms
- Pickle encode: 24ms
- Pickle decode: 42ms
- Roundtrip:     71ms