### PR TITLE
2: Use tuples for all AST collection fields (instead of lists)

### DIFF
--- a/docs/usage/parser.rst
+++ b/docs/usage/parser.rst
@@ -35,30 +35,30 @@ This will give the same result as manually creating the AST document::
 
     from graphql.language.ast import *
 
-    document = DocumentNode(definitions=[
+    document = DocumentNode(definitions=(
         ObjectTypeDefinitionNode(
             name=NameNode(value='Query'),
-            fields=[
+            fields=(
                 FieldDefinitionNode(
                     name=NameNode(value='me'),
                     type=NamedTypeNode(name=NameNode(value='User')),
-                    arguments=[], directives=[])
-                ], directives=[], interfaces=[]),
+                    arguments=(), directives=()),
+                ), interfaces=(), directives=()),
         ObjectTypeDefinitionNode(
             name=NameNode(value='User'),
-            fields=[
+            fields=(
                 FieldDefinitionNode(
                     name=NameNode(value='id'),
                     type=NamedTypeNode(
                         name=NameNode(value='ID')),
-                    arguments=[], directives=[]),
+                    arguments=(), directives=()),
                 FieldDefinitionNode(
                     name=NameNode(value='name'),
                     type=NamedTypeNode(
                         name=NameNode(value='String')),
-                    arguments=[], directives=[]),
-                ], directives=[], interfaces=[]),
-        ])
+                    arguments=(), directives=()),
+                ), interfaces=(), directives=()),
+        ))
 
 
 When parsing with ``no_location=False`` (the default), the AST nodes will also have a

--- a/src/graphql/utilities/ast_to_dict.py
+++ b/src/graphql/utilities/ast_to_dict.py
@@ -45,14 +45,18 @@ def ast_to_dict(
         elif node in cache:
             return cache[node]
         cache[node] = res = {}
+        # Note: We don't use msgspec.structs.asdict() because loc needs special
+        # handling (converted to {start, end} dict rather than full Location object)
+        # Filter out 'loc' - it's handled separately for the locations option
+        fields = [f for f in node.keys if f != "loc"]
         res.update(
             {
                 key: ast_to_dict(getattr(node, key), locations, cache)
-                for key in ("kind", *node.keys[1:])
+                for key in ("kind", *fields)
             }
         )
         if locations:
-            loc = node.loc
+            loc = getattr(node, "loc", None)
             if loc:
                 res["loc"] = {"start": loc.start, "end": loc.end}
         return res

--- a/src/graphql/utilities/concat_ast.py
+++ b/src/graphql/utilities/concat_ast.py
@@ -17,6 +17,5 @@ def concat_ast(asts: Collection[DocumentNode]) -> DocumentNode:
     the ASTs together into batched AST, useful for validating many GraphQL source files
     which together represent one conceptual application.
     """
-    return DocumentNode(
-        definitions=list(chain.from_iterable(document.definitions for document in asts))
-    )
+    all_definitions = chain.from_iterable(doc.definitions for doc in asts)
+    return DocumentNode(definitions=tuple(all_definitions))

--- a/src/graphql/utilities/separate_operations.py
+++ b/src/graphql/utilities/separate_operations.py
@@ -60,7 +60,7 @@ def separate_operations(document_ast: DocumentNode) -> dict[str, DocumentNode]:
         # The list of definition nodes to be included for this operation, sorted
         # to retain the same order as the original document.
         separated_document_asts[operation_name] = DocumentNode(
-            definitions=[
+            definitions=tuple(
                 node
                 for node in document_ast.definitions
                 if node is operation
@@ -68,7 +68,7 @@ def separate_operations(document_ast: DocumentNode) -> dict[str, DocumentNode]:
                     isinstance(node, FragmentDefinitionNode)
                     and node.name.value in dependencies
                 )
-            ]
+            )
         )
 
     return separated_document_asts

--- a/tests/benchmarks/test_serialization.py
+++ b/tests/benchmarks/test_serialization.py
@@ -1,0 +1,50 @@
+"""Benchmarks for pickle serialization of parsed queries.
+
+This module benchmarks pickle serialization using a large query (~100KB)
+to provide realistic performance numbers for query caching use cases.
+"""
+
+import pickle
+
+from graphql import parse
+
+from ..fixtures import large_query  # noqa: F401
+
+# Parse benchmark
+
+
+def test_parse_large_query(benchmark, large_query):  # noqa: F811
+    """Benchmark parsing large query."""
+    result = benchmark(lambda: parse(large_query, no_location=True))
+    assert result is not None
+
+
+# Pickle benchmarks
+
+
+def test_pickle_large_query_roundtrip(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle roundtrip for large query AST."""
+    document = parse(large_query, no_location=True)
+
+    def roundtrip():
+        encoded = pickle.dumps(document)
+        return pickle.loads(encoded)
+
+    result = benchmark(roundtrip)
+    assert result == document
+
+
+def test_pickle_large_query_encode(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle encoding for large query AST."""
+    document = parse(large_query, no_location=True)
+    result = benchmark(lambda: pickle.dumps(document))
+    assert isinstance(result, bytes)
+
+
+def test_pickle_large_query_decode(benchmark, large_query):  # noqa: F811
+    """Benchmark pickle decoding for large query AST."""
+    document = parse(large_query, no_location=True)
+    encoded = pickle.dumps(document)
+
+    result = benchmark(lambda: pickle.loads(encoded))
+    assert result == document

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
     "cleanup",
     "kitchen_sink_query",
     "kitchen_sink_sdl",
+    "large_query",
 ]
 
 
@@ -54,3 +55,8 @@ def big_schema_sdl():
 @pytest.fixture(scope="module")
 def big_schema_introspection_result():
     return read_json("github_schema")
+
+
+@pytest.fixture(scope="module")
+def large_query():
+    return read_graphql("large_query")

--- a/tests/fixtures/large_query.graphql
+++ b/tests/fixtures/large_query.graphql
@@ -1,0 +1,7006 @@
+# Large query for serialization benchmarks
+query LargeQuery(
+  $orgId: ID!
+  $first: Int!
+  $after: String
+  $includeArchived: Boolean = false
+  $searchTerm: String
+  $sortBy: SortOrder = DESC
+) {
+  viewer {
+    id
+    login
+    name
+    email
+  }
+
+  org0: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members0: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos0: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org1: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members1: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos1: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org2: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members2: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos2: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org3: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members3: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos3: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org4: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members4: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos4: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org5: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members5: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos5: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org6: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members6: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos6: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org7: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members7: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos7: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org8: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members8: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos8: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org9: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members9: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos9: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org10: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members10: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos10: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org11: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members11: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos11: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org12: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members12: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos12: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org13: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members13: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos13: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org14: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members14: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos14: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org15: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members15: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos15: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org16: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members16: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos16: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org17: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members17: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos17: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org18: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members18: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos18: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org19: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members19: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos19: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org20: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members20: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos20: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org21: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members21: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos21: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org22: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members22: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos22: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org23: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members23: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos23: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org24: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members24: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos24: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org25: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members25: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos25: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org26: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members26: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos26: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org27: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members27: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos27: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org28: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members28: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos28: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org29: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members29: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos29: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org30: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members30: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos30: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org31: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members31: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos31: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org32: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members32: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos32: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org33: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members33: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos33: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org34: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members34: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos34: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org35: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members35: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos35: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org36: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members36: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos36: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org37: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members37: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos37: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org38: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members38: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos38: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org39: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members39: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos39: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org40: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members40: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos40: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org41: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members41: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos41: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org42: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members42: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos42: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org43: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members43: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos43: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org44: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members44: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos44: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org45: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members45: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos45: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org46: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members46: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos46: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org47: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members47: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos47: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org48: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members48: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos48: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+
+  org49: organization(id: $orgId) {
+    id
+    name
+    description
+    createdAt
+    updatedAt
+    membersCount
+    teamsCount
+    repositoriesCount
+    
+    owner {
+      id
+      login
+      email
+      avatarUrl
+      createdAt
+    }
+    
+    members49: members(first: $first, after: $after) {
+      pageInfo {
+        hasNextPage
+        hasPreviousPage
+        startCursor
+        endCursor
+      }
+      totalCount
+      edges {
+        cursor
+        node {
+          id
+          login
+          name
+          email
+          avatarUrl
+          bio
+          company
+          location
+          websiteUrl
+          twitterUsername
+          createdAt
+          updatedAt
+          isHireable
+          pronouns
+          followers {
+            totalCount
+          }
+          following {
+            totalCount
+          }
+          repositories {
+            totalCount
+          }
+          gists {
+            totalCount
+          }
+          starredRepositories {
+            totalCount
+          }
+        }
+      }
+    }
+    
+    repos49: repositories(first: $first, after: $after, includeArchived: $includeArchived) {
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+      edges {
+        node {
+          id
+          name
+          nameWithOwner
+          description
+          url
+          homepageUrl
+          isPrivate
+          isArchived
+          isFork
+          isEmpty
+          isTemplate
+          createdAt
+          updatedAt
+          pushedAt
+          diskUsage
+          
+          primaryLanguage {
+            id
+            name
+            color
+          }
+          
+          stargazerCount
+          forkCount
+          watcherCount
+          
+          defaultBranchRef {
+            name
+            target {
+              ... on Commit {
+                id
+                message
+                messageHeadline
+                committedDate
+                author {
+                  name
+                  email
+                  date
+                }
+              }
+            }
+          }
+          
+          licenseInfo {
+            key
+            name
+            spdxId
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment UserFragment0 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment0 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment1 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment1 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment2 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment2 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment3 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment3 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment4 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment4 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment5 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment5 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment6 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment6 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment7 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment7 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment8 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment8 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment9 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment9 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment10 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment10 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment11 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment11 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment12 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment12 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment13 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment13 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment14 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment14 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment15 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment15 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment16 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment16 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment17 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment17 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment18 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment18 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}
+
+fragment UserFragment19 on User {
+  id
+  login
+  name
+  email
+  avatarUrl
+  bio
+  company
+  location
+  websiteUrl
+  twitterUsername
+  createdAt
+  updatedAt
+  isHireable
+  pronouns
+  status {
+    message
+    emoji
+  }
+}
+
+fragment RepositoryFragment19 on Repository {
+  id
+  name
+  nameWithOwner
+  description
+  url
+  homepageUrl
+  isPrivate
+  isArchived
+  isFork
+  isEmpty
+  isTemplate
+  createdAt
+  updatedAt
+  pushedAt
+  diskUsage
+  stargazerCount
+  forkCount
+  watcherCount
+}

--- a/tests/language/test_schema_parser.py
+++ b/tests/language/test_schema_parser.py
@@ -78,12 +78,12 @@ def name_node(name: str, loc: Location):
 
 
 def field_node(name: NameNode, type_: TypeNode, loc: Location):
-    return field_node_with_args(name, type_, [], loc)
+    return field_node_with_args(name, type_, (), loc)
 
 
-def field_node_with_args(name: NameNode, type_: TypeNode, args: list, loc: Location):
+def field_node_with_args(name: NameNode, type_: TypeNode, args: tuple, loc: Location):
     return FieldDefinitionNode(
-        name=name, arguments=args, type=type_, directives=[], loc=loc, description=None
+        name=name, arguments=args, type=type_, directives=(), loc=loc, description=None
     )
 
 
@@ -93,7 +93,7 @@ def non_null_type(type_: TypeNode, loc: Location):
 
 def enum_value_node(name: str, loc: Location):
     return EnumValueDefinitionNode(
-        name=name_node(name, loc), directives=[], loc=loc, description=None
+        name=name_node(name, loc), directives=(), loc=loc, description=None
     )
 
 
@@ -104,7 +104,7 @@ def input_value_node(
         name=name,
         type=type_,
         default_value=default_value,
-        directives=[],
+        directives=(),
         loc=loc,
         description=None,
     )
@@ -123,8 +123,8 @@ def list_type_node(type_: TypeNode, loc: Location):
 
 
 def schema_extension_node(
-    directives: list[DirectiveNode],
-    operation_types: list[OperationTypeDefinitionNode],
+    directives: tuple[DirectiveNode, ...],
+    operation_types: tuple[OperationTypeDefinitionNode, ...],
     loc: Location,
 ):
     return SchemaExtensionNode(
@@ -136,7 +136,7 @@ def operation_type_definition(operation: OperationType, type_: TypeNode, loc: Lo
     return OperationTypeDefinitionNode(operation=operation, type=type_, loc=loc)
 
 
-def directive_node(name: NameNode, arguments: list[ArgumentNode], loc: Location):
+def directive_node(name: NameNode, arguments: tuple[ArgumentNode, ...], loc: Location):
     return DirectiveNode(name=name, arguments=arguments, loc=loc)
 
 
@@ -351,14 +351,14 @@ def describe_schema_parser():
         assert doc.loc == (0, 75)
         assert doc.definitions == (
             schema_extension_node(
-                [],
-                [
+                (),
+                (
                     operation_type_definition(
                         OperationType.MUTATION,
                         type_node("Mutation", (53, 61)),
                         (43, 61),
-                    )
-                ],
+                    ),
+                ),
                 (13, 75),
             ),
         )
@@ -370,8 +370,8 @@ def describe_schema_parser():
         assert doc.loc == (0, 24)
         assert doc.definitions == (
             schema_extension_node(
-                [directive_node(name_node("directive", (15, 24)), [], (14, 24))],
-                [],
+                (directive_node(name_node("directive", (15, 24)), (), (14, 24)),),
+                (),
                 (0, 24),
             ),
         )
@@ -571,14 +571,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (38, 44)),
-                [
+                (
                     input_value_node(
                         name_node("flag", (22, 26)),
                         type_node("Boolean", (28, 35)),
                         None,
                         (22, 35),
-                    )
-                ],
+                    ),
+                ),
                 (16, 44),
             ),
         )
@@ -602,14 +602,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (45, 51)),
-                [
+                (
                     input_value_node(
                         name_node("flag", (22, 26)),
                         type_node("Boolean", (28, 35)),
                         boolean_value_node(True, (38, 42)),
                         (22, 42),
-                    )
-                ],
+                    ),
+                ),
                 (16, 51),
             ),
         )
@@ -633,14 +633,14 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (41, 47)),
-                [
+                (
                     input_value_node(
                         name_node("things", (22, 28)),
                         list_type_node(type_node("String", (31, 37)), (30, 38)),
                         None,
                         (22, 38),
-                    )
-                ],
+                    ),
+                ),
                 (16, 47),
             ),
         )
@@ -664,7 +664,7 @@ def describe_schema_parser():
             field_node_with_args(
                 name_node("world", (16, 21)),
                 type_node("String", (53, 59)),
-                [
+                (
                     input_value_node(
                         name_node("argOne", (22, 28)),
                         type_node("Boolean", (30, 37)),
@@ -677,7 +677,7 @@ def describe_schema_parser():
                         None,
                         (39, 50),
                     ),
-                ],
+                ),
                 (16, 59),
             ),
         )

--- a/tests/utilities/test_ast_from_value.py
+++ b/tests/utilities/test_ast_from_value.py
@@ -204,13 +204,13 @@ def describe_ast_from_value():
         assert ast_from_value(
             ["FOO", "BAR"], GraphQLList(GraphQLString)
         ) == ConstListValueNode(
-            values=[StringValueNode(value="FOO"), StringValueNode(value="BAR")]
+            values=(StringValueNode(value="FOO"), StringValueNode(value="BAR"))
         )
 
         assert ast_from_value(
             ["HELLO", "GOODBYE"], GraphQLList(my_enum)
         ) == ConstListValueNode(
-            values=[EnumValueNode(value="HELLO"), EnumValueNode(value="GOODBYE")]
+            values=(EnumValueNode(value="HELLO"), EnumValueNode(value="GOODBYE"))
         )
 
         def list_generator():
@@ -220,11 +220,11 @@ def describe_ast_from_value():
 
         assert ast_from_value(list_generator(), GraphQLList(GraphQLInt)) == (
             ConstListValueNode(
-                values=[
+                values=(
                     IntValueNode(value="1"),
                     IntValueNode(value="2"),
                     IntValueNode(value="3"),
-                ]
+                )
             )
         )
 
@@ -239,7 +239,7 @@ def describe_ast_from_value():
         )
 
         assert ast == ConstListValueNode(
-            values=[StringValueNode(value="FOO"), StringValueNode(value="BAR")]
+            values=(StringValueNode(value="FOO"), StringValueNode(value="BAR"))
         )
 
     input_obj = GraphQLInputObjectType(
@@ -251,21 +251,21 @@ def describe_ast_from_value():
         assert ast_from_value(
             {"foo": 3, "bar": "HELLO"}, input_obj
         ) == ConstObjectValueNode(
-            fields=[
+            fields=(
                 ConstObjectFieldNode(
                     name=NameNode(value="foo"), value=FloatValueNode(value="3")
                 ),
                 ConstObjectFieldNode(
                     name=NameNode(value="bar"), value=EnumValueNode(value="HELLO")
                 ),
-            ]
+            )
         )
 
     def converts_input_objects_with_explicit_nulls():
         assert ast_from_value({"foo": None}, input_obj) == ConstObjectValueNode(
-            fields=[
-                ConstObjectFieldNode(name=NameNode(value="foo"), value=NullValueNode())
-            ]
+            fields=(
+                ConstObjectFieldNode(name=NameNode(value="foo"), value=NullValueNode()),
+            )
         )
 
     def does_not_convert_non_object_values_as_input_objects():

--- a/tests/utilities/test_build_ast_schema.py
+++ b/tests/utilities/test_build_ast_schema.py
@@ -133,7 +133,7 @@ def describe_schema_builder():
 
     def match_order_of_default_types_and_directives():
         schema = GraphQLSchema()
-        sdl_schema = build_ast_schema(DocumentNode(definitions=[]))
+        sdl_schema = build_ast_schema(DocumentNode(definitions=()))
 
         assert sdl_schema.directives == schema.directives
         assert sdl_schema.type_map == schema.type_map

--- a/tests/utilities/test_type_info.py
+++ b/tests/utilities/test_type_info.py
@@ -346,7 +346,7 @@ def describe_visit_with_type_info():
                         arguments=node.arguments,
                         directives=node.directives,
                         selection_set=SelectionSetNode(
-                            selections=[FieldNode(name=NameNode(value="__typename"))]
+                            selections=(FieldNode(name=NameNode(value="__typename")),)
                         ),
                     )
 


### PR DESCRIPTION
Prepares AST for immutability by using tuples instead of lists for
collection fields. This aligns with the JavaScript GraphQL library
which uses readonly arrays, and enables future frozen datastructures.

Note: It looks like you can't easily make stacked PRs in an open source repo you do not have write access to, since the merge base does not exist in the remote. 