### PR TITLE
Switch to typing_extensions.Self for __new__ implementations

### DIFF
--- a/src/graphql/pyutils/undefined.py
+++ b/src/graphql/pyutils/undefined.py
@@ -1,9 +1,15 @@
 """The Undefined value"""
 
 from __future__ import annotations
-from typing_extensions import Self
 
 import warnings
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    try:
+        from typing import Self
+    except ImportError:  # Python < 3.11
+        from typing_extensions import Self
 
 __all__ = ["Undefined", "UndefinedType"]
 
@@ -11,7 +17,7 @@ __all__ = ["Undefined", "UndefinedType"]
 class UndefinedType:
     """Auxiliary class for creating the Undefined singleton."""
 
-    _instance: UndefinedType | None = None
+    _instance: Self | None = None
 
     def __new__(cls) -> Self:
         """Create the Undefined singleton."""

--- a/src/graphql/pyutils/undefined.py
+++ b/src/graphql/pyutils/undefined.py
@@ -1,6 +1,7 @@
 """The Undefined value"""
 
 from __future__ import annotations
+from typing_extensions import Self
 
 import warnings
 
@@ -12,7 +13,7 @@ class UndefinedType:
 
     _instance: UndefinedType | None = None
 
-    def __new__(cls) -> UndefinedType:
+    def __new__(cls) -> Self:
         """Create the Undefined singleton."""
         if cls._instance is None:
             cls._instance = super().__new__(cls)

--- a/src/graphql/type/definition.py
+++ b/src/graphql/type/definition.py
@@ -14,7 +14,6 @@ from typing import (
     cast,
     overload,
 )
-from typing_extensions import Self
 
 if TYPE_CHECKING:
     from typing import TypeAlias, TypeGuard
@@ -59,6 +58,11 @@ from .assert_name import assert_enum_value_name, assert_name
 
 if TYPE_CHECKING:
     from .schema import GraphQLSchema
+
+    try:
+        from typing import Self
+    except ImportError:  # Python < 3.11
+        from typing_extensions import Self
 
 
 __all__ = [

--- a/src/graphql/type/definition.py
+++ b/src/graphql/type/definition.py
@@ -14,6 +14,7 @@ from typing import (
     cast,
     overload,
 )
+from typing_extensions import Self
 
 if TYPE_CHECKING:
     from typing import TypeAlias, TypeGuard
@@ -232,7 +233,7 @@ class GraphQLNamedType(GraphQLType):
 
     reserved_types: Mapping[str, GraphQLNamedType] = {}
 
-    def __new__(cls, name: str, *_args: Any, **_kwargs: Any) -> GraphQLNamedType:
+    def __new__(cls, name: str, *_args: Any, **_kwargs: Any) -> Self:
         """Create a GraphQL named type."""
         if name in cls.reserved_types:
             msg = f"Redefinition of reserved type {name!r}"


### PR DESCRIPTION
I noticed that when running with https://pyrefly.org/ I get type errors on things like:

```python
from graphql import GraphQLEnumType

def get_enum() -> GraphQLEnumType:
  return GraphQLEnumType()
```

This occurs because the `__new__` function for `GraphQLNamedType` returns `GraphQLNamedType` (i.e. that *exact* class) instead of `Self` which automatically infers the actual class (e.g. `GraphQLEnumType` in this case).

I used the `typing_extensions` version because AIUI this project supports versions of python from before `Self` was introduced, and I also fixed the other `__new__` function that returns a type while I was fixing the problem I was seeing.