### PR TITLE
camel_to_snake adds underscore after digits

### DIFF
--- a/src/graphql/pyutils/convert_case.py
+++ b/src/graphql/pyutils/convert_case.py
@@ -6,7 +6,7 @@ import re
 
 __all__ = ["camel_to_snake", "snake_to_camel"]
 
-_re_camel_to_snake = re.compile(r"([a-z]|[A-Z0-9]+)(?=[A-Z])")
+_re_camel_to_snake = re.compile(r"([a-z]|[A-Z0-9]+(?=[A-Z])|[0-9]+)(?=[A-Z])")
 _re_snake_to_camel = re.compile(r"(_)([a-z\d])")
 
 


### PR DESCRIPTION
Fixed regex to add underscore between digit sequences and uppercase letters. Example: camel_to_snake('python2Thing') now returns 'python2_thing' instead of 'python2thing'.
