### PR TITLE
Fix mypy 2.3.0 type errors in the test suite

### DIFF
--- a/tests/execution/test_abstract.py
+++ b/tests/execution/test_abstract.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import pytest
 
@@ -18,6 +18,9 @@ from graphql.type import (
     GraphQLUnionType,
 )
 from graphql.utilities import build_schema
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def sync_and_async(spec):
@@ -51,6 +54,7 @@ async def execute_query(
 
 def get_is_type_of(type_, sync=True):
     """Get a sync or async is_type_of function for the given type."""
+    is_type_of: Callable[[Any, Any], Any]
     if sync:
 
         def is_type_of(obj, _info):
@@ -67,6 +71,7 @@ def get_is_type_of(type_, sync=True):
 def get_type_error(sync=True):
     """Get a sync or async is_type_of or type resolver function that raises an error."""
     error = RuntimeError("We are testing this error")
+    type_error: Callable[..., Any]
     if sync:
 
         def type_error(*_args):

--- a/tests/execution/test_middleware.py
+++ b/tests/execution/test_middleware.py
@@ -4,7 +4,13 @@ from typing import cast
 
 import pytest
 
-from graphql.execution import Middleware, MiddlewareManager, execute, subscribe
+from graphql.execution import (
+    ExecutionResult,
+    Middleware,
+    MiddlewareManager,
+    execute,
+    subscribe,
+)
 from graphql.language.parser import parse
 from graphql.type import GraphQLField, GraphQLObjectType, GraphQLSchema, GraphQLString
 
@@ -262,9 +268,9 @@ def describe_middleware():
                 middleware=MiddlewareManager(reverse_middleware),
             )
             assert inspect.isasyncgen(agen)
-            data = (await agen.__anext__()).data
+            data = cast("ExecutionResult", await agen.__anext__()).data
             assert data == {"bar": "rab"}
-            data = (await agen.__anext__()).data
+            data = cast("ExecutionResult", await agen.__anext__()).data
             assert data == {"bar": "foo"}
 
     def describe_without_manager():

--- a/tests/execution/test_stream.py
+++ b/tests/execution/test_stream.py
@@ -1691,6 +1691,7 @@ def describe_execute_stream_directive():
             async def __anext__(self):
                 count = self.count
                 self.count += 1
+                name: Any
                 if count == 1:
                     name = throw()
                 else:
@@ -1757,6 +1758,7 @@ def describe_execute_stream_directive():
                     raise StopAsyncIteration  # pragma: no cover
                 count = self.count
                 self.count += 1
+                name: Any
                 if count == 1:
                     name = throw()
                 else:

--- a/tests/utils/assert_equal_awaitables_or_values.py
+++ b/tests/utils/assert_equal_awaitables_or_values.py
@@ -23,7 +23,7 @@ def assert_equal_awaitables_or_values(*items: T) -> T:
         async def assert_matching_awaitables():
             return assert_matching_values(*(await asyncio.gather(*awaitable_items)))
 
-        return assert_matching_awaitables()
+        return cast("T", assert_matching_awaitables())
 
     if all(not is_awaitable(item) for item in items):
         return assert_matching_values(*items)


### PR DESCRIPTION
mypy 2.3.0 (released 2026-07-13) is stricter and produces 7 errors on unmodified `main` — CI's `mypy<3,>=2.1` floats to it, so the Lint job now fails on every open PR. This fixes them. All changes are test-only with no behavioural change.

## Errors fixed

| File | mypy error | Fix |
| --- | --- | --- |
| `tests/utils/assert_equal_awaitables_or_values.py` | return value `Coroutine` vs declared TypeVar `T` | `cast("T", …)` — the helper returns an awaitable iff its inputs are awaitables |
| `tests/execution/test_abstract.py` (×2) | conditional `is_type_of` / `type_error` sync-vs-async variants must have identical signatures | pre-declare each as `Callable[..., Any]` |
| `tests/execution/test_stream.py` (×2) | `name` assigned either a coroutine (`throw()`) or a `str` | annotate `name: Any` |
| `tests/execution/test_middleware.py` (×2) | awaited `subscribe(...)` item inferred as `object`, so `.data` is rejected | `cast("ExecutionResult", …)` |

## Verification (pinned tool versions)

- `python -m mypy src tests` — Success, no issues (mypy 2.3.0)
- `python -m ruff check src tests` / `ruff format --check src tests` — clean (ruff 0.15.21)
- Affected test files (`test_abstract`, `test_stream`, `test_middleware`) pass unchanged.
